### PR TITLE
Use includes on shaded plugin instead of excludes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,9 @@
                     <configuration>
                         <minimizeJar>true</minimizeJar>
                         <artifactSet>
-                            <excludes>
-                                <exclude>org.junit.jupiter:junit-jupiter-api</exclude>
-                                <exclude>com.google.code.findbugs:jsr305</exclude>
-                            </excludes>
+                            <includes>
+                                <include>com.tdunning.math</include>
+                            </includes>
                         </artifactSet>
                         <relocations>
                             <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
                         <minimizeJar>true</minimizeJar>
                         <artifactSet>
                             <includes>
-                                <include>com.tdunning.math</include>
+                                <include>com.tdunning</include>
                             </includes>
                         </artifactSet>
                         <relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
                         <minimizeJar>true</minimizeJar>
                         <artifactSet>
                             <includes>
-                                <include>com.tdunning</include>
+                                <include>com.tdunning:t-digest</include>
                             </includes>
                         </artifactSet>
                         <relocations>


### PR DESCRIPTION
This change is protect against making a FAT JAR is future. But has no effect now.