### PR TITLE
Read data based on available bytes in the stream

### DIFF
--- a/src/main/java/com/wavefront/sdk/direct/ingestion/DataIngesterService.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/DataIngesterService.java
@@ -44,8 +44,11 @@ public class DataIngesterService implements DataIngesterAPI {
       urlConn.setReadTimeout(READ_TIMEOUT_MILLIS);
 
       try (GZIPOutputStream gzipOS = new GZIPOutputStream(urlConn.getOutputStream())) {
-        byte[] buffer = new byte[4096];
-        while (stream.read(buffer) > 0) {
+        // As long as there are bytes remaining to be read, read them in chunks of 4k bytes.
+        while (stream.available() > 0) {
+          // Allocate only as much as required.
+          byte[] buffer = new byte[Math.min(stream.available(), 4096)];
+          stream.read(buffer);
           gzipOS.write(buffer);
         }
         gzipOS.flush();

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/DataIngesterService.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/DataIngesterService.java
@@ -44,12 +44,9 @@ public class DataIngesterService implements DataIngesterAPI {
       urlConn.setReadTimeout(READ_TIMEOUT_MILLIS);
 
       try (GZIPOutputStream gzipOS = new GZIPOutputStream(urlConn.getOutputStream())) {
-        // As long as there are bytes remaining to be read, read them in chunks of 4k bytes.
+        byte[] buffer = new byte[4096];
         while (stream.available() > 0) {
-          // Allocate only as much as required.
-          byte[] buffer = new byte[Math.min(stream.available(), 4096)];
-          stream.read(buffer);
-          gzipOS.write(buffer);
+          gzipOS.write(buffer, 0, stream.read(buffer));
         }
         gzipOS.flush();
       }


### PR DESCRIPTION
When reading data to gzip and send to the endpoint, keep reading in 4kb chunks. If the data
is not exactly 4k aligned then in the last iteration, allocate the buffer for only that many
bytes that remains in the stream.

## Testing
I setup a proxy locally and changed the Main.java to send 10000 points to it.

```java
  private static void sendMetricViaDirectIngestion(
      WavefrontDirectIngestionClient wavefrontDirectIngestionClient) throws IOException {
    /*
     * Wavefront Metrics Data format
     * <metricName> <metricValue> [<timestamp>] source=<source> [pointTags]
     *
     * Example: "new-york.power.usage 42422 1533529977 source=localhost datacenter=dc1"
     */

    Map<String, String> tags = new HashMap<String, String>() {{
      put("datacenter", "dc1");
    }};
    for (int i = 0; i < 10000; i ++) {
      wavefrontDirectIngestionClient.sendMetric("new-york.power.usage", 42422.0, null,
                                                "localhost", tags);
    }
    System.out.println("Sent metric: 'new-york.power.usage' to direct ingestion API");
  }
```
This will cause this kind of parsing error failure in the proxy logs (this is not the exact error, but a similar one will appear everytime):
```
INFO: [2878] blocked input: [WF-300 Cannot parse: "vsphere.virtualDisk.numberWriteAveraged.average.rate.number 0.0 1552338120 source=xxx-xxx-761a458b-971b-4c09-b720-e85e4ed8878b esx_host=xx-xxxx-xxx.xx.xxxx.com vm_uuid=4216cee9-bb6a-8c4d-8018-412f86c5e79f instance=scsi0:12 sddc_env=local vc_uuid=3e68dc47-46f5-479e-8f40-ecc88c74e65b vm_name=xxxx-xxxxx-032"; remote: 0:0:0:0:0:0:0:1 [2878]; reason: "Syntax error at line 1, position 227: token recognition error at: ':1'"]
```
## Fix
Instead of allocating and reading 4096 bytes everytime, keep reading in 4kb chunks. In the last chunk, allocate and read only the remaining amount of bytes. We must also not allocate the bytes array outside the loop where we do the actual reading of stream bytes. This will keep overriding the previous buffer. Cases where we need to read < 4kb of data, we will allow stray data from the previous iteration to remain in the buffer causing this issue.

## Repercussions
Now that we are making allocations within the while loop for reading data, we might add a tiny amount of pressure on the young gen collector. But this might not be too much (I haven't measured how much faster we grow the young gen with the fix). 

Resolves #68 