### PR TITLE
Wavefront Metric Sender supports sending raw WF-formatted strings

### DIFF
--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -126,13 +126,17 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
                          @Nullable String source, @Nullable Map<String, String> tags)
       throws IOException {
     String point = metricToLineData(name, value, timestamp, source, tags, DEFAULT_SOURCE);
-    sendMetric(point);
+    sendFormattedMetric(point);
   }
 
   @Override
-  public void sendMetric(String point) throws IOException {
-    if (!metricsBuffer.offer(point)) {
-      logger.log(Level.WARNING, "Buffer full, dropping metric point: " + point);
+  public void sendFormattedMetric(String point) throws IOException {
+    if (point == null || "".equals(point.trim())) {
+      throw new IllegalArgumentException("point must be non-null and in WF data format");
+    }
+    String finalPoint = point.endsWith("\n") ? point : point + "\n";
+    if (!metricsBuffer.offer(finalPoint)) {
+      logger.log(Level.WARNING, "Buffer full, dropping metric point: " + finalPoint);
     }
   }
 

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -126,6 +126,11 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
                          @Nullable String source, @Nullable Map<String, String> tags)
       throws IOException {
     String point = metricToLineData(name, value, timestamp, source, tags, DEFAULT_SOURCE);
+    sendMetric(point);
+  }
+
+  @Override
+  public void sendMetric(String point) throws IOException {
     if (!metricsBuffer.offer(point)) {
       logger.log(Level.WARNING, "Buffer full, dropping metric point: " + point);
     }

--- a/src/main/java/com/wavefront/sdk/entities/metrics/WavefrontMetricSender.java
+++ b/src/main/java/com/wavefront/sdk/entities/metrics/WavefrontMetricSender.java
@@ -32,6 +32,15 @@ public interface WavefrontMetricSender {
                   @Nullable Map<String, String> tags) throws IOException;
 
   /**
+   * Similar to {@link #sendMetric(String, double, Long, String, Map)}, only the {@code point}
+   * argument is expected to already be in Wavefront Data Format
+   *
+   * @param point a single metric, encoded in Wavefront Data Format
+   * @throws IOException if there was an error sending the metric.
+   */
+  void sendMetric(String point) throws IOException;
+
+  /**
    * Sends the given delta counter to Wavefront. The timestamp for the point on the client side is
    * null because the final timestamp of the delta counter is assigned when the point is
    * aggregated on the server side. Do not use this method to send older points (say around 5 min

--- a/src/main/java/com/wavefront/sdk/entities/metrics/WavefrontMetricSender.java
+++ b/src/main/java/com/wavefront/sdk/entities/metrics/WavefrontMetricSender.java
@@ -38,7 +38,7 @@ public interface WavefrontMetricSender {
    * @param point a single metric, encoded in Wavefront Data Format
    * @throws IOException if there was an error sending the metric.
    */
-  void sendMetric(String point) throws IOException;
+  void sendFormattedMetric(String point) throws IOException;
 
   /**
    * Sends the given delta counter to Wavefront. The timestamp for the point on the client side is

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -181,7 +181,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     scheduler.scheduleAtFixedRate(this, 1, builder.flushIntervalSeconds, TimeUnit.SECONDS);
   }
 
-  private boolean setupSendMetric() throws IOException {
+  private boolean setupConnection() throws IOException {
     if (metricsProxyConnectionHandler == null) {
       logger.warning("Can't send data to Wavefront. " +
               "Please configure metrics port for Wavefront proxy");
@@ -202,7 +202,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
   public void sendMetric(String name, double value, @Nullable Long timestamp,
                          @Nullable String source, @Nullable Map<String, String> tags)
       throws IOException {
-    if (!setupSendMetric()) {
+    if (!setupConnection()) {
       return;
     }
 
@@ -220,8 +220,8 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
   }
 
   @Override
-  public void sendMetric(String point) throws IOException {
-    if (!setupSendMetric()) {
+  public void sendFormattedMetric(String point) throws IOException {
+    if (!setupConnection()) {
       return;
     }
 

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -181,14 +181,11 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     scheduler.scheduleAtFixedRate(this, 1, builder.flushIntervalSeconds, TimeUnit.SECONDS);
   }
 
-  @Override
-  public void sendMetric(String name, double value, @Nullable Long timestamp,
-                         @Nullable String source, @Nullable Map<String, String> tags)
-      throws IOException {
+  private boolean setupSendMetric() throws IOException {
     if (metricsProxyConnectionHandler == null) {
       logger.warning("Can't send data to Wavefront. " +
               "Please configure metrics port for Wavefront proxy");
-      return;
+      return false;
     }
 
     if (!metricsProxyConnectionHandler.isConnected()) {
@@ -198,11 +195,39 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
         // already connected.
       }
     }
+    return true;
+  }
+
+  @Override
+  public void sendMetric(String name, double value, @Nullable Long timestamp,
+                         @Nullable String source, @Nullable Map<String, String> tags)
+      throws IOException {
+    if (!setupSendMetric()) {
+      return;
+    }
 
     try {
       try {
         String lineData = metricToLineData(name, value, timestamp, source, tags, defaultSource);
         metricsProxyConnectionHandler.sendData(lineData);
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+    } catch (IOException e) {
+      metricsProxyConnectionHandler.incrementFailureCount();
+      throw e;
+    }
+  }
+
+  @Override
+  public void sendMetric(String point) throws IOException {
+    if (!setupSendMetric()) {
+      return;
+    }
+
+    try {
+      try {
+        metricsProxyConnectionHandler.sendData(point);
       } catch (Exception e) {
         throw new IOException(e);
       }


### PR DESCRIPTION
This enables clients to leverage the compression and batching features
already provided by the SDK without forcing them to supply individual
metric details separately (metric name, value, point-tags, etc.).

A client can send a metric point already in raw WF format.