### PR TITLE
Add @NonNullApi to set package level non-null semantics

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/annotation/NonNullApi.java
+++ b/src/main/java/com/wavefront/sdk/common/annotation/NonNullApi.java
@@ -1,0 +1,26 @@
+package com.wavefront.sdk.common.annotation;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A common annotation to declare that parameters and return values
+ * are to be considered as non-nullable by default for a given package.
+ * <p>
+ * Annotate package declaration in "package-info.java" files, then it
+ * sets the non-nullable semantics to the package.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Nonnull
+@TypeQualifierDefault({ElementType.METHOD, ElementType.PARAMETER})
+public @interface NonNullApi {
+}


### PR DESCRIPTION
Hi,

Currently, there are `@NonNull` and `@Nullable` in sdk, but annotating `@NonNull` is just half of the nullability enforcement.
You need to add package level annotation to make the semantics of default parameters and return values to be non-null under the package.

This PR just adds `@NonNullApi` annotation.

To enforce nullability, you need to add `package-info.java` and annotate the package declaration with `@NonNullApi`. This sets the default semantics to non-null, then annotate `@Nullable` for things that can be null.

FYI, If you want to support Kotlin, this null-safety is important.
