### PR TITLE
Add support for empty span tag values. Dont reject the span if span t…

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import static com.wavefront.sdk.common.Constants.SPAN_LOG_KEY;
@@ -158,7 +159,8 @@ public class Utils {
                                              @Nullable List<UUID> parents,
                                              @Nullable List<UUID> followsFrom,
                                              @Nullable List<Pair<String, String>> tags,
-                                             @Nullable List<SpanLog> spanLogs, String defaultSource) {
+                                             @Nullable List<SpanLog> spanLogs,
+                                             String defaultSource, @Nullable Logger logger) {
     /*
      * Wavefront Tracing Span Data format
      * <tracingSpanName> source=<source> [pointTags] <start_millis> <duration_milli_seconds>
@@ -207,8 +209,10 @@ public class Utils {
           throw new IllegalArgumentException("span tag key cannot be blank");
         }
         if (val == null || val.isEmpty()) {
-          throw new IllegalArgumentException("span tag value cannot be blank for " +
-              "tag key: " + key);
+          if (logger != null) {
+            logger.warning("span tag value cannot be blank for tag key: " + key);
+          }
+          continue;
         }
         sb.append(' ');
         sb.append(sanitize(key));

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -276,7 +276,7 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
     String span;
     try {
       span = tracingSpanToLineData(name, startMillis, durationMillis, source, traceId,
-          spanId, parents, followsFrom, tags, spanLogs, defaultSource);
+          spanId, parents, followsFrom, tags, spanLogs, defaultSource, logger);
       spansValid.inc();
     } catch (IllegalArgumentException e) {
       spansInvalid.inc();

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -353,7 +353,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     String lineData;
     try {
       lineData = tracingSpanToLineData(name, startMillis, durationMillis, source, traceId,
-          spanId, parents, followsFrom, tags, spanLogs, defaultSource);
+          spanId, parents, followsFrom, tags, spanLogs, defaultSource, logger);
       spansValid.inc();
     } catch (IllegalArgumentException e) {
       spansInvalid.inc();

--- a/src/test/java/com/wavefront/sdk/common/UtilsTest.java
+++ b/src/test/java/com/wavefront/sdk/common/UtilsTest.java
@@ -139,7 +139,7 @@ public class UtilsTest {
             Arrays.asList(UUID.fromString("2f64e538-9457-11e8-9eb6-529269fb1459")),
             Arrays.asList(UUID.fromString("5f64e538-9457-11e8-9eb6-529269fb1459")),
             Arrays.asList(new Pair<>("application", "Wavefront"),
-                new Pair<>("http.method", "GET")), null, "defaultSource"));
+                new Pair<>("http.method", "GET")), null, "defaultSource", null));
 
     // null followsFrom
     assertEquals("\"getAllUsers\" source=\"localhost\" " +
@@ -151,7 +151,7 @@ public class UtilsTest {
             UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
             Arrays.asList(UUID.fromString("2f64e538-9457-11e8-9eb6-529269fb1459")), null,
         Arrays.asList(new Pair<>("application", "Wavefront"),
-            new Pair<>("http.method", "GET")), null, "defaultSource"));
+            new Pair<>("http.method", "GET")), null, "defaultSource", null));
 
     // root span
     assertEquals("\"getAllUsers\" source=\"localhost\" " +
@@ -162,7 +162,7 @@ public class UtilsTest {
             UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"), UUID.fromString(
                 "0313bafe-9457-11e8-9eb6-529269fb1459"), null, null,
             Arrays.asList(new Pair<>("application", "Wavefront"),
-                new Pair<>("http.method", "GET")), null, "defaultSource"));
+                new Pair<>("http.method", "GET")), null, "defaultSource", null));
 
     // null tags
     assertEquals("\"getAllUsers\" source=\"localhost\" " +
@@ -173,7 +173,18 @@ public class UtilsTest {
             UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"), UUID.fromString(
                 "0313bafe-9457-11e8-9eb6-529269fb1459"), null, null, null, new ArrayList<SpanLog>() {{
                   add(new SpanLog(System.currentTimeMillis(), new HashMap<>()));
-                }}, "defaultSource"));
+                }}, "defaultSource", null));
+
+    // empty tags
+    assertEquals("\"getAllUsers\" source=\"localhost\" " +
+            "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
+            "\"abc\"=\"123\" \"_spanLogs\"=\"true\" 1493773500 343500\n",
+        tracingSpanToLineData("getAllUsers", 1493773500L, 343500L, "localhost",
+            UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"), UUID.fromString(
+                "0313bafe-9457-11e8-9eb6-529269fb1459"), null, null,
+                Arrays.asList(Pair.of("abc", "123"), Pair.of("emptyTagKey", "")),
+                new ArrayList<SpanLog>() {{ add(new SpanLog(System.currentTimeMillis(), new HashMap<>()));
+            }}, "defaultSource", null));
   }
 
   @Test


### PR DESCRIPTION
…ag value is empty. Drop that tag with warning message but send the rest of the span to Wavefront