### PR TITLE
Addressed various race conditions causing thread leakage

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -289,7 +289,7 @@ public class Utils {
     return toReturn.toString();
   }
 
-  public static void shutdownPoolAndWait(ExecutorService tpe) {
+  public static void shutdownExecutorAndWait(ExecutorService tpe) {
     tpe.shutdown();
     try {
       if (!tpe.awaitTermination(60, TimeUnit.SECONDS)) {

--- a/src/main/java/com/wavefront/sdk/common/application/HeartbeaterService.java
+++ b/src/main/java/com/wavefront/sdk/common/application/HeartbeaterService.java
@@ -96,7 +96,7 @@ public class HeartbeaterService implements Runnable, Closeable {
   @Override
   public void close() {
     try {
-      Utils.shutdownPoolAndWait(scheduler);
+      Utils.shutdownExecutorAndWait(scheduler);
     } catch (SecurityException ex) {
       logger.log(Level.FINE, "shutdown error", ex);
     }

--- a/src/main/java/com/wavefront/sdk/common/application/HeartbeaterService.java
+++ b/src/main/java/com/wavefront/sdk/common/application/HeartbeaterService.java
@@ -2,6 +2,7 @@ package com.wavefront.sdk.common.application;
 
 import com.wavefront.sdk.common.Constants;
 import com.wavefront.sdk.common.NamedThreadFactory;
+import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.entities.metrics.WavefrontMetricSender;
 
 import java.io.Closeable;
@@ -95,7 +96,7 @@ public class HeartbeaterService implements Runnable, Closeable {
   @Override
   public void close() {
     try {
-      scheduler.shutdownNow();
+      Utils.shutdownPoolAndWait(scheduler);
     } catch (SecurityException ex) {
       logger.log(Level.FINE, "shutdown error", ex);
     }

--- a/src/main/java/com/wavefront/sdk/common/metrics/WavefrontSdkMetricsRegistry.java
+++ b/src/main/java/com/wavefront/sdk/common/metrics/WavefrontSdkMetricsRegistry.java
@@ -154,7 +154,7 @@ public class WavefrontSdkMetricsRegistry implements Runnable, Closeable {
 
   @Override
   public void close() {
-    Utils.shutdownPoolAndWait(scheduler);
+    Utils.shutdownExecutorAndWait(scheduler);
   }
 
   /**

--- a/src/main/java/com/wavefront/sdk/common/metrics/WavefrontSdkMetricsRegistry.java
+++ b/src/main/java/com/wavefront/sdk/common/metrics/WavefrontSdkMetricsRegistry.java
@@ -1,6 +1,7 @@
 package com.wavefront.sdk.common.metrics;
 
 import com.wavefront.sdk.common.NamedThreadFactory;
+import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.entities.metrics.WavefrontMetricSender;
 
 import java.io.Closeable;
@@ -153,11 +154,7 @@ public class WavefrontSdkMetricsRegistry implements Runnable, Closeable {
 
   @Override
   public void close() {
-    try {
-      scheduler.shutdownNow();
-    } catch (SecurityException ex) {
-      logger.log(Level.FINE, "shutdown error", ex);
-    }
+    Utils.shutdownPoolAndWait(scheduler);
   }
 
   /**

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -429,7 +429,7 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
     sdkMetricsRegistry.close();
 
     try {
-      Utils.shutdownPoolAndWait(scheduler);
+      Utils.shutdownExecutorAndWait(scheduler);
     } catch (SecurityException ex) {
       logger.log(Level.WARNING, "shutdown error", ex);
     }

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -1,10 +1,7 @@
 package com.wavefront.sdk.direct.ingestion;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.wavefront.sdk.common.Constants;
-import com.wavefront.sdk.common.NamedThreadFactory;
-import com.wavefront.sdk.common.Pair;
-import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.*;
 import com.wavefront.sdk.common.annotation.Nullable;
 import com.wavefront.sdk.common.metrics.WavefrontSdkCounter;
 import com.wavefront.sdk.common.metrics.WavefrontSdkMetricsRegistry;
@@ -26,6 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -83,6 +81,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
   private final WavefrontSdkCounter spanLogsInvalid;
   private final WavefrontSdkCounter spanLogsDropped;
   private final WavefrontSdkCounter spanLogReportErrors;
+
+  // Flag to prevent sending after close() has been called
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   public static class Builder {
     // Required parameters
@@ -231,6 +232,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
   public void sendMetric(String name, double value, @Nullable Long timestamp,
                          @Nullable String source, @Nullable Map<String, String> tags)
       throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     String point;
     try {
       point = metricToLineData(name, value, timestamp, source, tags, defaultSource);
@@ -248,6 +252,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
 
   @Override
   public void sendFormattedMetric(String point) throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     if (point == null || "".equals(point.trim())) {
       pointsInvalid.inc();
       throw new IllegalArgumentException("point must be non-null and in WF data format");
@@ -267,6 +274,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
                                @Nullable Long timestamp, @Nullable String source,
                                @Nullable Map<String, String> tags)
       throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     String histograms;
     try {
       histograms = histogramToLineData(name, centroids, histogramGranularities, timestamp,
@@ -289,6 +299,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
                        @Nullable List<UUID> parents, @Nullable List<UUID> followsFrom,
                        @Nullable List<Pair<String, String>> tags, @Nullable List<SpanLog> spanLogs)
       throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     String span;
     try {
       span = tracingSpanToLineData(name, startMillis, durationMillis, source, traceId,
@@ -340,6 +353,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
 
   @Override
   public void flush() throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to flush closed sender");
+    }
     internalFlush(metricsBuffer, Constants.WAVEFRONT_METRIC_FORMAT, "points",
         pointsDropped, pointReportErrors);
     internalFlush(histogramsBuffer, Constants.WAVEFRONT_HISTOGRAM_FORMAT, "histograms",
@@ -400,6 +416,9 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
 
   @Override
   public synchronized void close() {
+    if(!closed.compareAndSet(false, true)) {
+      logger.log(Level.FINE,"attempt to close already closed sender");
+    }
     // Flush before closing
     try {
       flush();
@@ -410,7 +429,7 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
     sdkMetricsRegistry.close();
 
     try {
-      scheduler.shutdownNow();
+      Utils.shutdownPoolAndWait(scheduler);
     } catch (SecurityException ex) {
       logger.log(Level.WARNING, "shutdown error", ex);
     }

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -353,17 +353,21 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
 
   @Override
   public void flush() throws IOException {
-    if(closed.get()) {
-      throw new IOException("attempt to flush closed sender");
-    }
-    internalFlush(metricsBuffer, Constants.WAVEFRONT_METRIC_FORMAT, "points",
-        pointsDropped, pointReportErrors);
-    internalFlush(histogramsBuffer, Constants.WAVEFRONT_HISTOGRAM_FORMAT, "histograms",
-        histogramsDropped, histogramReportErrors);
-    internalFlush(tracingSpansBuffer, Constants.WAVEFRONT_TRACING_SPAN_FORMAT, "spans",
-        spansDropped, spanReportErrors);
-    internalFlush(spanLogsBuffer, Constants.WAVEFRONT_SPAN_LOG_FORMAT, "span_logs",
-        spanLogsDropped, spanLogReportErrors);
+      if(closed.get()) {
+          throw new IOException("attempt to flush closed sender");
+      }
+      this.flushNoCheck();
+  }
+
+  private void flushNoCheck() throws IOException {
+      internalFlush(metricsBuffer, Constants.WAVEFRONT_METRIC_FORMAT, "points",
+              pointsDropped, pointReportErrors);
+      internalFlush(histogramsBuffer, Constants.WAVEFRONT_HISTOGRAM_FORMAT, "histograms",
+              histogramsDropped, histogramReportErrors);
+      internalFlush(tracingSpansBuffer, Constants.WAVEFRONT_TRACING_SPAN_FORMAT, "spans",
+              spansDropped, spanReportErrors);
+      internalFlush(spanLogsBuffer, Constants.WAVEFRONT_SPAN_LOG_FORMAT, "span_logs",
+              spanLogsDropped, spanLogReportErrors);
   }
 
   private void internalFlush(LinkedBlockingQueue<String> buffer, String format, String entityPrefix,
@@ -421,7 +425,7 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
     }
     // Flush before closing
     try {
-      flush();
+      flushNoCheck();
     } catch (IOException e) {
       logger.log(Level.WARNING, "error flushing buffer", e);
     }

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -414,11 +414,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     }
   }
 
-  @Override
-  public void flush() throws IOException {
-    if(closed.get()) {
-      throw new IOException("attempt to flush closed sender");
-    }
+  private void flushNoCheck() throws IOException {
     if (metricsProxyConnectionHandler != null) {
       metricsProxyConnectionHandler.flush();
     }
@@ -430,6 +426,14 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     if (tracingProxyConnectionHandler != null) {
       tracingProxyConnectionHandler.flush();
     }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to flush closed sender");
+    }
+    this.flushNoCheck();
   }
 
   @Override
@@ -458,7 +462,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
 
     // Flush before closing
     try {
-      flush();
+      flushNoCheck();
     } catch (IOException e) {
       logger.log(Level.WARNING, "error flushing buffer", e);
     }

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -464,7 +464,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     }
 
     try {
-      Utils.shutdownPoolAndWait(scheduler);
+      Utils.shutdownExecutorAndWait(scheduler);
     } catch (SecurityException ex) {
       logger.log(Level.FINE, "shutdown error", ex);
     }

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -1,10 +1,7 @@
 package com.wavefront.sdk.proxy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.wavefront.sdk.common.Constants;
-import com.wavefront.sdk.common.NamedThreadFactory;
-import com.wavefront.sdk.common.Pair;
-import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.*;
 import com.wavefront.sdk.common.annotation.Nullable;
 import com.wavefront.sdk.common.metrics.WavefrontSdkCounter;
 import com.wavefront.sdk.common.metrics.WavefrontSdkMetricsRegistry;
@@ -23,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -85,6 +83,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
   private final WavefrontSdkCounter spanLogsValid;
   private final WavefrontSdkCounter spanLogsInvalid;
   private final WavefrontSdkCounter spanLogsDropped;
+
+  // Flag to prevent sending after close() has been called
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   public static class Builder {
     // Required parameters
@@ -252,6 +253,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
   public void sendMetric(String name, double value, @Nullable Long timestamp,
                          @Nullable String source, @Nullable Map<String, String> tags)
       throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     if (metricsProxyConnectionHandler == null) {
       pointsDiscarded.inc();
       logger.warning("Can't send data to Wavefront. " +
@@ -279,6 +283,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
 
   @Override
   public void sendFormattedMetric(String point) throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     if (metricsProxyConnectionHandler == null) {
       pointsDiscarded.inc();
       logger.warning("Can't send data to Wavefront. " +
@@ -308,6 +315,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
                                @Nullable Long timestamp, @Nullable String source,
                                @Nullable Map<String, String> tags)
       throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     if (histogramProxyConnectionHandler == null) {
       histogramsDiscarded.inc();
       logger.warning("Can't send data to Wavefront. " +
@@ -340,6 +350,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
                        @Nullable List<UUID> parents, @Nullable List<UUID> followsFrom,
                        @Nullable List<Pair<String, String>> tags, @Nullable List<SpanLog> spanLogs)
       throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to send using closed sender");
+    }
     if (tracingProxyConnectionHandler == null) {
       spansDiscarded.inc();
       if (spanLogs != null && !spanLogs.isEmpty()) {
@@ -403,6 +416,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
 
   @Override
   public void flush() throws IOException {
+    if(closed.get()) {
+      throw new IOException("attempt to flush closed sender");
+    }
     if (metricsProxyConnectionHandler != null) {
       metricsProxyConnectionHandler.flush();
     }
@@ -435,6 +451,9 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
 
   @Override
   public void close() {
+    if(!closed.compareAndSet(false, true)) {
+     logger.log(Level.FINE,"attempt to close already closed sender");
+    }
     sdkMetricsRegistry.close();
 
     // Flush before closing
@@ -445,7 +464,7 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
     }
 
     try {
-      scheduler.shutdownNow();
+      Utils.shutdownPoolAndWait(scheduler);
     } catch (SecurityException ex) {
       logger.log(Level.FINE, "shutdown error", ex);
     }

--- a/src/test/java/com/wavefront/sdk/proxy/ProxyTest.java
+++ b/src/test/java/com/wavefront/sdk/proxy/ProxyTest.java
@@ -1,8 +1,5 @@
 package com.wavefront.sdk.proxy;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import com.wavefront.sdk.common.WavefrontSender;
 import org.junit.jupiter.api.Test;
 
@@ -15,12 +12,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ProxyTest {
     private final int NUM_THREADS = 10;
     private final int NUM_ITERATIONS = 1000;
 
     private final int THREAD_WAIT_ITERATIONS = 10;
+
+    private final static Pattern linePattern = Pattern.compile("\"dummy\" 1\\.0 [0-9]+ source=\"dummy\"");
 
     private final class MockServer implements Runnable {
         public void run() {
@@ -31,7 +33,7 @@ public class ProxyTest {
                 int n = 0;
                 String line;
                 while ((line = in.readLine()) != null) {
-                    System.out.println(line);
+                    assertTrue(linePattern.matcher(line).matches(), "Unexpected data from sender");
                     n++;
                 }
                 assertEquals(NUM_ITERATIONS * NUM_THREADS, n, "Wrong number of messages received");
@@ -100,7 +102,7 @@ public class ProxyTest {
                     }
                     if(!tMap.containsKey(t.getId()) && !t.isDaemon()) {
                         ++newT;
-                        System.out.println("Non-daemon thread still running: " + t.toString());
+                        System.out.println("Non-daemon thread still running: " + t.toString() + ". Waiting for it to finish");
                     }
                 }
                 if(newT > 0) {

--- a/src/test/java/com/wavefront/sdk/proxy/ProxyTest.java
+++ b/src/test/java/com/wavefront/sdk/proxy/ProxyTest.java
@@ -1,0 +1,123 @@
+package com.wavefront.sdk.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.wavefront.sdk.common.WavefrontSender;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+public class ProxyTest {
+    private final int NUM_THREADS = 10;
+    private final int NUM_ITERATIONS = 1000;
+
+    private final int THREAD_WAIT_ITERATIONS = 10;
+
+    private final class MockServer implements Runnable {
+        public void run() {
+            try {
+                ServerSocket s = new ServerSocket(12345);
+                Socket cs = s.accept();
+                BufferedReader in = new BufferedReader(new InputStreamReader(cs.getInputStream()));
+                int n = 0;
+                String line;
+                while ((line = in.readLine()) != null) {
+                    System.out.println(line);
+                    n++;
+                }
+                assertEquals(NUM_ITERATIONS * NUM_THREADS, n, "Wrong number of messages received");
+            } catch(IOException e) {
+                fail(e);
+            }
+        }
+    }
+
+    private static final Thread[] getAllThreads() {
+        ThreadGroup rootGroup = Thread.currentThread().getThreadGroup();
+        ThreadGroup parentGroup;
+        while ((parentGroup = rootGroup.getParent()) != null) {
+            rootGroup = parentGroup;
+        }
+        Thread[] threads = new Thread[rootGroup.activeCount()];
+        while (rootGroup.enumerate(threads, true ) == threads.length) {
+            threads = new Thread[threads.length * 2];
+        }
+        return threads;
+    }
+
+    @Test
+    public void testProxyRoundtrip() {
+        try {
+            // Take a snapshot of active threads before we start the client
+            Thread[] threads = getAllThreads();
+            Map<Long, Thread> tMap = new HashMap<>();
+            for(Thread t : threads) {
+                if(t == null) {
+                    continue;
+                }
+                tMap.put(t.getId(), t);
+            }
+            Thread server = new Thread(new MockServer());
+            server.setDaemon(false);
+            server.start();
+            WavefrontProxyClient.Builder b = new WavefrontProxyClient.Builder("localhost");
+            b.metricsPort(12345);
+            final WavefrontSender s = b.build();
+            final Semaphore semaphore = new Semaphore(0);
+            for(int i = 0; i < NUM_THREADS; ++i) {
+                new Thread(() -> {
+                    for (int j = 0; j < NUM_ITERATIONS; ++j) {
+                        try {
+                            s.sendMetric("dummy", 1.0, System.currentTimeMillis(), "dummy", new HashMap<>());
+                        } catch(IOException e) {
+                            fail(e);
+                        }
+                    }
+                    semaphore.release();
+                }).start();
+            }
+
+           semaphore.acquire(NUM_THREADS);
+            s.close();
+
+            // Wait for all new non-daemon threads to terminate (or timeout)
+            int n = 0;
+            for(;;) {
+                threads = getAllThreads();
+                int newT = 0;
+                for(Thread t : threads) {
+                    if(t == null) {
+                        break;
+                    }
+                    if(!tMap.containsKey(t.getId()) && !t.isDaemon()) {
+                        ++newT;
+                        System.out.println("Non-daemon thread still running: " + t.toString());
+                    }
+                }
+                if(newT > 0) {
+                    n++;
+                    if(n >= THREAD_WAIT_ITERATIONS) {
+                        fail("Gave up waiting for threads to exit");
+                    }
+                    Thread.sleep(1000);
+                } else {
+                    break;
+                }
+            }
+        } catch(IOException e) {
+            fail(e);
+        }
+        catch(InterruptedException e) {
+            fail(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR is intended to close issue #108.

A call to Sender::close() could cause non-deamon threads to be left running preventing the process from exiting. This was caused by two separate race conditions.

1) It was possible to call the various send* functions on a closed Sender. This caused the new ```ReconnectingSocket``` objects to be created, but since the cancel on their timers was supposed to have already been called when closing the senders, the timers were never cancelled. Addressed this by maintaining a flag on the sender indicating if it's closed and by throwing exceptions if operations were attempted on a closed sender.

2) Various Executors were created throughout the code. When a sender is closed, all these executors were terminated using the ```shutdownNow()``` method. This posed a problem, since there's no guarantee all tasks had finished. This, in turn, could cause calls that would create new ```ReconnectingSocket``` with stray timers just like described above. Changed the code so that all attempts to shut down Executors are waiting for all tasks to finish before continuing. This could cause calls to ```Sender::close()``` to block for a short time, but it's reasonable to assume that callers are expecting the state after a call to close() to be one where all work has been finished.