### PR TITLE
Add build.version info to sdk metrics.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-sdk-java</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -44,6 +44,15 @@
     </distributionManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/wavefront/sdk/common/Constants.java
+++ b/src/main/java/com/wavefront/sdk/common/Constants.java
@@ -1,5 +1,7 @@
 package com.wavefront.sdk.common;
 
+import java.util.regex.Pattern;
+
 /**
  * Class to define all java-sdk constants
  *
@@ -114,4 +116,10 @@ public final class Constants {
    * Name prefix for internal diagnostic metrics for Wavefront SDKs.
    */
   public static final String SDK_METRIC_PREFIX = "~sdk.java";
+
+  /**
+   * Semantic version pattern matcher regex.
+   */
+  public static final Pattern SEMVER_PATTERN = Pattern.
+      compile("([0-9]\\d*)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9]+))?");
 }

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -394,19 +394,19 @@ public class Utils {
     if (version != null && !version.isEmpty()) {
       Matcher semVerMatcher = SEMVER_PATTERN.matcher(version);
       if (semVerMatcher.matches()) {
-        //Major version
+        // Major version
         StringBuilder sdkVersion = new StringBuilder(semVerMatcher.group(1));
         sdkVersion.append(".");
         String minor = semVerMatcher.group(2);
         String patch = semVerMatcher.group(3);
         String snapshot = semVerMatcher.group(4);
-        //Minor version
+        // Minor version
         if (minor.length() == 1) {
           sdkVersion.append("0" + minor);
         } else {
           sdkVersion.append(minor);
         }
-        //Patch Version
+        // Patch Version
         if (patch.length() == 1) {
           sdkVersion.append("0" + patch);
         } else {

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -16,7 +16,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 
+import static com.wavefront.sdk.common.Constants.SEMVER_PATTERN;
 import static com.wavefront.sdk.common.Constants.SPAN_LOG_KEY;
 
 /**
@@ -374,5 +376,35 @@ public class Utils {
     } catch (Exception ex) {
       return "";
     }
+  }
+
+  public static double getSemVer(String version) {
+    Matcher semVerMatcher = SEMVER_PATTERN.matcher(version);
+    if (semVerMatcher.matches()) {
+      //Major version
+      StringBuilder sdkVersion = new StringBuilder(semVerMatcher.group(1));
+      sdkVersion.append(".");
+      String minor = semVerMatcher.group(2);
+      String patch = semVerMatcher.group(3);
+      String snapshot = semVerMatcher.group(4);
+      //Minor version
+      if (minor.length() == 1) {
+        sdkVersion.append("0" + minor);
+      } else {
+        sdkVersion.append(minor);
+      }
+      //Patch Version
+      if (patch.length() == 1) {
+        sdkVersion.append("0" + patch);
+      } else {
+        sdkVersion.append(patch);
+      }
+      try {
+        return Double.valueOf(sdkVersion.toString());
+      } catch (Exception ex) {
+        logger.log(Level.FINE, ex.getMessage());
+      }
+    }
+    return 0.0D;
   }
 }

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -384,6 +384,8 @@ public class Utils {
     if (resourceBundle.containsKey("version")) {
       String version = resourceBundle.getString("version");
       return getSemVerValue(version);
+    } else {
+      logger.log(Level.INFO, "Could not retrieve build version info.");
     }
     return 0.0D;
   }

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -402,7 +402,7 @@ public class Utils {
       try {
         return Double.valueOf(sdkVersion.toString());
       } catch (Exception ex) {
-        logger.log(Level.WARNING, ex.getMessage());
+        logger.log(Level.INFO, ex.getMessage());
       }
     }
     return 0.0D;

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -379,6 +379,9 @@ public class Utils {
   }
 
   public static double getSemVer(String version) {
+    if (version == null || version.isEmpty()) {
+      return 0.0D;
+    }
     Matcher semVerMatcher = SEMVER_PATTERN.matcher(version);
     if (semVerMatcher.matches()) {
       //Major version

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -10,6 +10,7 @@ import com.wavefront.sdk.entities.tracing.SpanLogsDTO;
 
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -378,34 +379,42 @@ public class Utils {
     }
   }
 
-  public static double getSemVer(String version) {
-    if (version == null || version.isEmpty()) {
-      return 0.0D;
+  public static double getSemVer() {
+    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
+    if (resourceBundle.containsKey("version")) {
+      String version = resourceBundle.getString("version");
+      return getSemVerValue(version);
     }
-    Matcher semVerMatcher = SEMVER_PATTERN.matcher(version);
-    if (semVerMatcher.matches()) {
-      //Major version
-      StringBuilder sdkVersion = new StringBuilder(semVerMatcher.group(1));
-      sdkVersion.append(".");
-      String minor = semVerMatcher.group(2);
-      String patch = semVerMatcher.group(3);
-      String snapshot = semVerMatcher.group(4);
-      //Minor version
-      if (minor.length() == 1) {
-        sdkVersion.append("0" + minor);
-      } else {
-        sdkVersion.append(minor);
-      }
-      //Patch Version
-      if (patch.length() == 1) {
-        sdkVersion.append("0" + patch);
-      } else {
-        sdkVersion.append(patch);
-      }
-      try {
-        return Double.valueOf(sdkVersion.toString());
-      } catch (Exception ex) {
-        logger.log(Level.INFO, ex.getMessage());
+    return 0.0D;
+  }
+
+  public static double getSemVerValue(String version) {
+    if (version != null && !version.isEmpty()) {
+      Matcher semVerMatcher = SEMVER_PATTERN.matcher(version);
+      if (semVerMatcher.matches()) {
+        //Major version
+        StringBuilder sdkVersion = new StringBuilder(semVerMatcher.group(1));
+        sdkVersion.append(".");
+        String minor = semVerMatcher.group(2);
+        String patch = semVerMatcher.group(3);
+        String snapshot = semVerMatcher.group(4);
+        //Minor version
+        if (minor.length() == 1) {
+          sdkVersion.append("0" + minor);
+        } else {
+          sdkVersion.append(minor);
+        }
+        //Patch Version
+        if (patch.length() == 1) {
+          sdkVersion.append("0" + patch);
+        } else {
+          sdkVersion.append(patch);
+        }
+        try {
+          return Double.valueOf(sdkVersion.toString());
+        } catch (Exception ex) {
+          logger.log(Level.INFO, ex.getMessage());
+        }
       }
     }
     return 0.0D;

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -402,7 +402,7 @@ public class Utils {
       try {
         return Double.valueOf(sdkVersion.toString());
       } catch (Exception ex) {
-        logger.log(Level.FINE, ex.getMessage());
+        logger.log(Level.WARNING, ex.getMessage());
       }
     }
     return 0.0D;

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -278,7 +278,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
       double sdkVersion = getSemVer(version);
       sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
     } catch (IOException e) {
-      logger.log(e.getMessage(), Level.WARNING, "Error fetching version.");
+      logger.log(e.getMessage(), Level.INFO, "Error fetching version.");
     }
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -1,11 +1,9 @@
 package com.wavefront.sdk.common.clients;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 
-import com.fasterxml.jackson.databind.deser.DataFormatReaders;
-import com.wavefront.sdk.Main;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wavefront.sdk.common.Constants;
 import com.wavefront.sdk.common.NamedThreadFactory;
 import com.wavefront.sdk.common.Pair;
@@ -29,7 +27,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -40,8 +38,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.wavefront.sdk.common.Utils.getSemVer;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
@@ -271,14 +267,11 @@ public class WavefrontClient implements WavefrontSender, Runnable {
         sendSdkMetrics(builder.includeSdkMetrics).
         build();
 
-    try {
-      final Properties properties = new Properties();
-      properties.load(WavefrontClient.class.getResourceAsStream("/build.properties"));
-      String version = properties.getProperty("version");
+    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
+    if (resourceBundle.containsKey("version")) {
+      String version = resourceBundle.getString("version");
       double sdkVersion = getSemVer(version);
       sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-    } catch (IOException e) {
-      logger.log(e.getMessage(), Level.INFO, "Error fetching version.");
     }
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -3,6 +3,9 @@ package com.wavefront.sdk.common.clients;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.databind.deser.DataFormatReaders;
+import com.wavefront.sdk.Main;
 import com.wavefront.sdk.common.Constants;
 import com.wavefront.sdk.common.NamedThreadFactory;
 import com.wavefront.sdk.common.Pair;
@@ -26,6 +29,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -36,7 +40,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.wavefront.sdk.common.Utils.getSemVer;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.spanLogsToLineData;
@@ -263,6 +270,16 @@ public class WavefrontClient implements WavefrontSender, Runnable {
         tags(builder.tags).
         sendSdkMetrics(builder.includeSdkMetrics).
         build();
+
+    try {
+      final Properties properties = new Properties();
+      properties.load(WavefrontClient.class.getResourceAsStream("/build.properties"));
+      String version = properties.getProperty("version");
+      double sdkVersion = getSemVer(version);
+      sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
+    } catch (IOException e) {
+      logger.log(e.getMessage(), Level.INFO, "Error fetching version.");
+    }
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);
     sdkMetricsRegistry.newGauge("points.queue.remaining_capacity",

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -278,7 +278,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
       double sdkVersion = getSemVer(version);
       sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
     } catch (IOException e) {
-      logger.log(e.getMessage(), Level.INFO, "Error fetching version.");
+      logger.log(e.getMessage(), Level.WARNING, "Error fetching version.");
     }
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -27,7 +27,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -267,12 +266,8 @@ public class WavefrontClient implements WavefrontSender, Runnable {
         sendSdkMetrics(builder.includeSdkMetrics).
         build();
 
-    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
-    if (resourceBundle.containsKey("version")) {
-      String version = resourceBundle.getString("version");
-      double sdkVersion = getSemVer(version);
-      sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-    }
+    double sdkVersion = getSemVer();
+    sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);
     sdkMetricsRegistry.newGauge("points.queue.remaining_capacity",

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -212,9 +212,6 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
         tag(Constants.PROCESS_TAG_KEY, processId).
         build();
 
-    double sdkVersion = getSemVer();
-    sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);
     sdkMetricsRegistry.newGauge("points.queue.remaining_capacity",
         metricsBuffer::remainingCapacity);

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.wavefront.sdk.common.Utils.getSemVer;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.spanLogsToLineData;

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -25,7 +25,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -213,12 +212,8 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
         tag(Constants.PROCESS_TAG_KEY, processId).
         build();
 
-    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
-    if (resourceBundle.containsKey("version")) {
-      String version = resourceBundle.getString("version");
-      double sdkVersion = getSemVer(version);
-      sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-    }
+    double sdkVersion = getSemVer();
+    sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);
     sdkMetricsRegistry.newGauge("points.queue.remaining_capacity",

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -1,14 +1,14 @@
 package com.wavefront.sdk.direct.ingestion;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wavefront.sdk.common.Constants;
 import com.wavefront.sdk.common.NamedThreadFactory;
 import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.annotation.Nullable;
-import com.wavefront.sdk.common.clients.WavefrontClient;
 import com.wavefront.sdk.common.clients.WavefrontClientFactory;
 import com.wavefront.sdk.common.logging.MessageDedupingLogger;
 import com.wavefront.sdk.common.metrics.WavefrontSdkCounter;
@@ -25,7 +25,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -213,14 +213,11 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
         tag(Constants.PROCESS_TAG_KEY, processId).
         build();
 
-    try {
-      final Properties properties = new Properties();
-      properties.load(WavefrontClient.class.getResourceAsStream("/build.properties"));
-      String version = properties.getProperty("version");
+    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
+    if (resourceBundle.containsKey("version")) {
+      String version = resourceBundle.getString("version");
       double sdkVersion = getSemVer(version);
       sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-    } catch (IOException e) {
-      logger.log(Level.INFO, "Error fetching version.");
     }
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -20,7 +20,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -199,12 +198,8 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
         tag(Constants.PROCESS_TAG_KEY, processId).
         build();
 
-    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
-    if (resourceBundle.containsKey("version")) {
-      String version = resourceBundle.getString("version");
-      double sdkVersion = getSemVer(version);
-      sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-    }
+    double sdkVersion = getSemVer();
+    sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
 
     String uniqueId = builder.proxyHostName + ":";
     if (builder.metricsPort == null) {

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -31,7 +31,6 @@ import java.util.logging.Logger;
 
 import javax.net.SocketFactory;
 
-import static com.wavefront.sdk.common.Utils.getSemVer;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.spanLogsToLineData;

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -7,14 +7,12 @@ import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.annotation.Nullable;
-import com.wavefront.sdk.common.clients.WavefrontClient;
 import com.wavefront.sdk.common.clients.WavefrontClientFactory;
 import com.wavefront.sdk.common.metrics.WavefrontSdkCounter;
 import com.wavefront.sdk.common.metrics.WavefrontSdkMetricsRegistry;
 import com.wavefront.sdk.entities.histograms.HistogramGranularity;
 import com.wavefront.sdk.entities.tracing.SpanLog;
 
-import javax.net.SocketFactory;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
@@ -22,7 +20,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -31,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.net.SocketFactory;
 
 import static com.wavefront.sdk.common.Utils.getSemVer;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
@@ -199,14 +199,11 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
         tag(Constants.PROCESS_TAG_KEY, processId).
         build();
 
-    try {
-      final Properties properties = new Properties();
-      properties.load(WavefrontClient.class.getResourceAsStream("/build.properties"));
-      String version = properties.getProperty("version");
+    ResourceBundle resourceBundle = ResourceBundle.getBundle("build");
+    if (resourceBundle.containsKey("version")) {
+      String version = resourceBundle.getString("version");
       double sdkVersion = getSemVer(version);
       sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-    } catch (IOException e) {
-      logger.log(Level.INFO, "Error fetching version.");
     }
 
     String uniqueId = builder.proxyHostName + ":";

--- a/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
+++ b/src/main/java/com/wavefront/sdk/proxy/WavefrontProxyClient.java
@@ -198,9 +198,6 @@ public class WavefrontProxyClient implements WavefrontSender, Runnable {
         tag(Constants.PROCESS_TAG_KEY, processId).
         build();
 
-    double sdkVersion = getSemVer();
-    sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
-
     String uniqueId = builder.proxyHostName + ":";
     if (builder.metricsPort == null) {
       metricsProxyConnectionHandler = null;

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/test/java/com/wavefront/sdk/common/UtilsTest.java
+++ b/src/test/java/com/wavefront/sdk/common/UtilsTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.wavefront.sdk.common.Utils.getSemVer;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.sanitize;
@@ -501,4 +502,24 @@ public class UtilsTest {
                 "\"application\"=\"Wavefront\" " +
                 "\"http.method\"=\"GET\" 1493773500 343500\n"));
   }
+
+  @Test
+  public void testSemVer() throws IOException {
+    assertEquals(1.0100D, getSemVer("1.1.0"));
+
+    assertEquals(1.0100D, getSemVer("1.1.0-SNAPSHOT"));
+
+    assertEquals(1.0101D, getSemVer("1.1.1"));
+
+    assertEquals(1.1001D, getSemVer("1.10.1"));
+
+    assertEquals(1.0110D, getSemVer("1.1.10"));
+
+    assertEquals(1.0001D, getSemVer("1.0.1"));
+
+    assertEquals(1.0010D, getSemVer("1.0.10"));
+
+    assertEquals(1.1010D, getSemVer("1.10.10"));
+  }
+
 }

--- a/src/test/java/com/wavefront/sdk/common/UtilsTest.java
+++ b/src/test/java/com/wavefront/sdk/common/UtilsTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.wavefront.sdk.common.Utils.getSemVer;
+import static com.wavefront.sdk.common.Utils.getSemVerValue;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.sanitize;
@@ -504,26 +505,26 @@ public class UtilsTest {
   }
 
   @Test
-  public void testSemVer() throws IOException {
-    assertEquals(0.0D, getSemVer(null));
+  public void testSemVerValue() throws IOException {
+    assertEquals(0.0D, getSemVerValue(null));
 
-    assertEquals(0.0D, getSemVer(""));
+    assertEquals(0.0D, getSemVerValue(""));
 
-    assertEquals(1.0100D, getSemVer("1.1.0"));
+    assertEquals(1.0100D, getSemVerValue("1.1.0"));
 
-    assertEquals(1.0100D, getSemVer("1.1.0-SNAPSHOT"));
+    assertEquals(1.0100D, getSemVerValue("1.1.0-SNAPSHOT"));
 
-    assertEquals(1.0101D, getSemVer("1.1.1"));
+    assertEquals(1.0101D, getSemVerValue("1.1.1"));
 
-    assertEquals(1.1001D, getSemVer("1.10.1"));
+    assertEquals(1.1001D, getSemVerValue("1.10.1"));
 
-    assertEquals(1.0110D, getSemVer("1.1.10"));
+    assertEquals(1.0110D, getSemVerValue("1.1.10"));
 
-    assertEquals(1.0001D, getSemVer("1.0.1"));
+    assertEquals(1.0001D, getSemVerValue("1.0.1"));
 
-    assertEquals(1.0010D, getSemVer("1.0.10"));
+    assertEquals(1.0010D, getSemVerValue("1.0.10"));
 
-    assertEquals(1.1010D, getSemVer("1.10.10"));
+    assertEquals(1.1010D, getSemVerValue("1.10.10"));
   }
 
 }

--- a/src/test/java/com/wavefront/sdk/common/UtilsTest.java
+++ b/src/test/java/com/wavefront/sdk/common/UtilsTest.java
@@ -505,6 +505,10 @@ public class UtilsTest {
 
   @Test
   public void testSemVer() throws IOException {
+    assertEquals(0.0D, getSemVer(null));
+
+    assertEquals(0.0D, getSemVer(""));
+
     assertEquals(1.0100D, getSemVer("1.1.0"));
 
     assertEquals(1.0100D, getSemVer("1.1.0-SNAPSHOT"));


### PR DESCRIPTION
We will be emitting the below metric from each client:
For version 2.6.1 , we will emit metric value as `2.0601`. The charts will need to be set as a single stat with a precision of 4 decimals.

~sdk.*.version 2.0601 source=<hostip>