### PR TITLE
 Incude a namespace separated build.properties files 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
                             <filter>
                                 <artifact>*:*</artifact>
                                 <excludes>
-                                    <exclude>META-INF/**</exclude>
+                                    <exclude>META-INF/license/**</exclude>
                                     <exclude>mozilla/**</exclude>
                                 </excludes>
                             </filter>

--- a/src/main/java/com/wavefront/sdk/common/Constants.java
+++ b/src/main/java/com/wavefront/sdk/common/Constants.java
@@ -122,4 +122,16 @@ public final class Constants {
    */
   public static final Pattern SEMVER_PATTERN = Pattern.
       compile("([0-9]\\d*)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9]+))?");
+
+  /**
+   * The Project Version of the sdk or artifactId in properties file.
+   */
+  public static final String VERSION = "project.version";
+
+
+  /**
+   * The root folder of the resources for a artifactId.
+   */
+  public static final String RESOURCES_ROOT = "META-INF/";
+
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.wavefront.sdk.common.Utils.getSemVer;
+import static com.wavefront.sdk.common.Utils.getSemVerGauge;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.spanLogsToLineData;
@@ -267,7 +267,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
         sendSdkMetrics(builder.includeSdkMetrics).
         build();
 
-    double sdkVersion = getSemVer();
+    double sdkVersion = getSemVerGauge("wavefront-sdk-java");
     sdkMetricsRegistry.newGauge("version", () -> sdkVersion);
 
     sdkMetricsRegistry.newGauge("points.queue.size", metricsBuffer::size);

--- a/src/main/resources/META-INF/wavefront-sdk-java/build.properties
+++ b/src/main/resources/META-INF/wavefront-sdk-java/build.properties
@@ -1,0 +1,1 @@
+project.version=${project.version}

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -1,1 +1,0 @@
-version=${project.version}

--- a/src/test/java/com/wavefront/sdk/common/UtilsTest.java
+++ b/src/test/java/com/wavefront/sdk/common/UtilsTest.java
@@ -14,16 +14,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.wavefront.sdk.common.Utils.getSemVer;
-import static com.wavefront.sdk.common.Utils.getSemVerValue;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
 import static com.wavefront.sdk.common.Utils.sanitize;
 import static com.wavefront.sdk.common.Utils.sanitizeValue;
 import static com.wavefront.sdk.common.Utils.sanitizeWithoutQuotes;
-import static com.wavefront.sdk.common.Utils.tracingSpanToLineData;
 import static com.wavefront.sdk.common.Utils.spanLogsToLineData;
-
+import static com.wavefront.sdk.common.Utils.tracingSpanToLineData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -505,26 +502,26 @@ public class UtilsTest {
   }
 
   @Test
-  public void testSemVerValue() throws IOException {
-    assertEquals(0.0D, getSemVerValue(null));
+  public void convertSemVerToGauge() throws IOException {
+    assertEquals(0.0D, Utils.convertSemVerToGauge(null));
 
-    assertEquals(0.0D, getSemVerValue(""));
+    assertEquals(0.0D, Utils.convertSemVerToGauge(""));
 
-    assertEquals(1.0100D, getSemVerValue("1.1.0"));
+    assertEquals(1.0100D, Utils.convertSemVerToGauge("1.1.0"));
 
-    assertEquals(1.0100D, getSemVerValue("1.1.0-SNAPSHOT"));
+    assertEquals(1.0100D, Utils.convertSemVerToGauge("1.1.0-SNAPSHOT"));
 
-    assertEquals(1.0101D, getSemVerValue("1.1.1"));
+    assertEquals(1.0101D, Utils.convertSemVerToGauge("1.1.1"));
 
-    assertEquals(1.1001D, getSemVerValue("1.10.1"));
+    assertEquals(1.1001D, Utils.convertSemVerToGauge("1.10.1"));
 
-    assertEquals(1.0110D, getSemVerValue("1.1.10"));
+    assertEquals(1.0110D, Utils.convertSemVerToGauge("1.1.10"));
 
-    assertEquals(1.0001D, getSemVerValue("1.0.1"));
+    assertEquals(1.0001D, Utils.convertSemVerToGauge("1.0.1"));
 
-    assertEquals(1.0010D, getSemVerValue("1.0.10"));
+    assertEquals(1.0010D, Utils.convertSemVerToGauge("1.0.10"));
 
-    assertEquals(1.1010D, getSemVerValue("1.10.10"));
+    assertEquals(1.1010D, Utils.convertSemVerToGauge("1.10.10"));
   }
 
 }


### PR DESCRIPTION
This change Includes : 
1. A new ns separated resource file "build.properties" to store the version info
2. Utility methods to get Resources/version info/ version gauge values reported etc. 

Tested with slim/uber jar and version info is retrieved correctly as long as resources are included in the jar.