### PR TITLE
Unshade and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,19 +92,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr1</version>
+            <version>2.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.3.1</version>
+            <version>5.7.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -117,7 +117,7 @@
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>
-            <version>3.6</version>
+            <version>4.3</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,47 +65,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                  <execution>
-                    <phase>package</phase>
-                    <goals>
-                      <goal>shade</goal>
-                    </goals>
-                    <configuration>
-                        <minimizeJar>true</minimizeJar>
-                        <artifactSet>
-                            <includes>
-                                <include>com.tdunning:t-digest</include>
-                                <include>com.google.guava</include>
-                            </includes>
-                        </artifactSet>
-                        <relocations>
-                            <relocation>
-                                <pattern>com.tdunning.math</pattern>
-                                <shadedPattern>com.wavefront.java_sdk.com.tdunning.math</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>com.google</pattern>
-                                <shadedPattern>com.wavefront.java_sdk.com.google</shadedPattern>
-                            </relocation>
-                        </relocations>
-                        <filters>
-                            <filter>
-                                <artifact>*:*</artifact>
-                                <excludes>
-                                    <exclude>META-INF/license/**</exclude>
-                                    <exclude>mozilla/**</exclude>
-                                </excludes>
-                            </filter>
-                        </filters>
-                    </configuration>
-                  </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5</version>
                 <configuration>


### PR DESCRIPTION
This removes shaded dependencies from the SDK, enabling users to update them indepdent of our release cadence when necessary.

This also updates dependencies to the latest versions:

- jackson-databind 2.12.4
- guava 30.1.1-jre
- junit-jupiter-api 5.7.2
- easymock 4.3

Skipped updating to t-digest 3.3 since it caused non-trivial failures in `WavefrontHistogramImplTest`. There wasn't a changelog for 3.3 describing why the behavior may have changed.
