### PR TITLE
Refactor WavefrontClientTest.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,13 @@
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -103,14 +107,8 @@
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.7.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.net.httpserver</groupId>
-            <artifactId>http</artifactId>
-            <version>20070405</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -254,9 +254,9 @@ public class WavefrontClient implements WavefrontSender, Runnable {
    * to make a connection
    *
    * @return {@code this}
-   * @throws IllegalStateException
+   * @throws IllegalArgumentException
    */
-    public Builder validateEndpoint() throws IllegalStateException {
+    public Builder validateEndpoint() throws IllegalArgumentException {
       URL url = null;
 
       try {

--- a/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientFactoryTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientFactoryTest.java
@@ -1,0 +1,77 @@
+package com.wavefront.sdk.common.clients;
+
+import com.wavefront.sdk.common.Pair;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WavefrontClientFactoryTest {
+  @Nested
+  class ParseEndpoint {
+    @Test
+    void throwsForNonHTTPScheme() {
+      assertThrows(IllegalArgumentException.class,
+          () -> WavefrontClientFactory.parseEndpoint("udp://host:2878"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "https://host     , https://host",
+        "https://host:4443, https://host:4443",
+        "http://host      , proxy://host",
+        "http://host:2878 , proxy://host:2878",
+        "http://host      , http://host",
+        "http://host:2878 , http://host:2878",
+    })
+    void simpleCases(String expectedUrl, String input) {
+      Pair<String, String> parsed = WavefrontClientFactory.parseEndpoint(input);
+
+      assertEquals(expectedUrl, parsed._1);
+      assertNull(parsed._2);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "https://host     , https://usr@host",
+        "https://host:4443, https://usr@host:4443",
+        "https://host:4443, https://usr@host:4443/path/",
+    })
+    void setsTokenFromUserInfo(String expectedUrl, String input) {
+      Pair<String, String> parsed = WavefrontClientFactory.parseEndpoint(input);
+
+      assertEquals(expectedUrl, parsed._1);
+      assertEquals("usr", parsed._2);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "http://host     , proxy://usr@host",
+        "http://host:2878, proxy://usr@host:2878",
+        "http://host:2878, http://usr@host:2878/path/",
+    })
+    void dropsTokenForUnencryptedEndpoint(String expectedUrl, String input) {
+      Pair<String, String> parsed = WavefrontClientFactory.parseEndpoint(input);
+
+      assertEquals(expectedUrl, parsed._1);
+      assertNull(parsed._2);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "https://host    , https://usr@host/path/",
+        "http://host     , proxy://host/path/",
+        "http://host:2878, http://host:2878/path/",
+    })
+    void stripsPathFromEndpoint(String expectedUrl, String input) {
+      Pair<String, String> parsed = WavefrontClientFactory.parseEndpoint(input);
+
+      assertEquals(expectedUrl, parsed._1);
+    }
+  }
+}

--- a/src/test/java/com/wavefront/sdk/common/clients/service/ReportingServiceTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/service/ReportingServiceTest.java
@@ -1,0 +1,52 @@
+package com.wavefront.sdk.common.clients.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.net.URI;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportingServiceTest {
+  @ParameterizedTest
+  @CsvSource({
+      "http://127.0.0.1:2878/report?f=wavefront         , http://127.0.0.1:2878",
+      "http://127.0.0.1:2878/report?f=wavefront         , http://127.0.0.1:2878/",
+      "http://127.0.0.1:2878/report?f=wavefront         , http://127.0.0.1:2878////",
+      "http://localhost:2878/report?f=wavefront         , http://localhost:2878/report",
+      "http://localhost:2878/report?f=wavefront         , http://localhost:2878/report/",
+      "https://domain.wavefront.com/report?f=wavefront  , https://domain.wavefront.com",
+      "https://domain.wavefront.com/report?f=wavefront  , https://domain.wavefront.com/",
+      "https://domain.wavefront.com/report?f=wavefront  , https://domain.wavefront.com/report",
+      "https://domain.wavefront.com/report?f=wavefront  , https://domain.wavefront.com/report/",
+      "http://a.proxy.b.com:2878/prod/report?f=wavefront, http://a.proxy.b.com:2878/prod/report/",
+  })
+  void testGetReportingUrl(String expectedUrl, String input) {
+    URL actualUrl = assertDoesNotThrow(() ->
+        ReportingService.getReportingUrl(URI.create(input), "wavefront"));
+
+    assertEquals(expectedUrl, actualUrl.toString());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "http://127.0.0.1:2878/api/v2/event         , http://127.0.0.1:2878",
+      "http://127.0.0.1:2878/api/v2/event         , http://127.0.0.1:2878/",
+      "http://127.0.0.1:2878/api/v2/event         , http://127.0.0.1:2878////",
+      "http://localhost:2878/api/v2/event         , http://localhost:2878/api/v2/event",
+      "http://localhost:2878/api/v2/event         , http://localhost:2878/api/v2/event/",
+      "https://domain.wavefront.com/api/v2/event  , https://domain.wavefront.com",
+      "https://domain.wavefront.com/api/v2/event  , https://domain.wavefront.com/",
+      "https://domain.wavefront.com/api/v2/event  , https://domain.wavefront.com/api/v2/event",
+      "https://domain.wavefront.com/api/v2/event  , https://domain.wavefront.com/api/v2/event/",
+      "http://a.proxy.b.com:2878/prod/api/v2/event, http://a.proxy.b.com:2878/prod/api/v2/event/",
+  })
+  void testGetEventReportingUrl(String expectedUrl, String input) {
+    URL actualUrl = assertDoesNotThrow(() ->
+        ReportingService.getEventReportingUrl(URI.create(input)));
+
+    assertEquals(expectedUrl, actualUrl.toString());
+  }
+}


### PR DESCRIPTION
- Pull out WavefrontClientFactory and ReportingService tests
- Use ParameterizedTests from JUnit 5
- Use simple ServerSocket instead of HTTPServer
- Fix exception in validateEndpoint() signature