### PR TITLE
WavefrontClient can send spans to different port than metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
             <scope>test</scope>
             <version>4.3</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+            <version>2.30.1</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/wavefront/sdk/common/clients/service/ReportingService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/ReportingService.java
@@ -24,8 +24,9 @@ import java.util.zip.GZIPOutputStream;
  */
 public class ReportingService implements ReportAPI {
 
-  private static final MessageSuppressingLogger MESSAGE_SUPPRESSING_LOGGER = new MessageSuppressingLogger(
-      Logger.getLogger(ReportingService.class.getCanonicalName()), 5, TimeUnit.MINUTES);
+  private static final MessageSuppressingLogger MESSAGE_SUPPRESSING_LOGGER =
+      new MessageSuppressingLogger(Logger.getLogger(ReportingService.class.getCanonicalName()),
+          5, TimeUnit.MINUTES);
 
   private final String token;
   private final URI uri;
@@ -35,8 +36,8 @@ public class ReportingService implements ReportAPI {
   private static final int BUFFER_SIZE = 4096;
   private static final int NO_HTTP_RESPONSE = -1;
 
-  public ReportingService(String server, @Nullable String token) {
-    this.uri = URI.create(server);
+  public ReportingService(URI uri, @Nullable String token) {
+    this.uri = uri;
     this.token = token;
   }
 

--- a/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientTest.java
@@ -1,7 +1,13 @@
 package com.wavefront.sdk.common.clients;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.metrics.WavefrontSdkDeltaCounter;
+import com.wavefront.sdk.entities.histograms.HistogramGranularity;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -9,9 +15,17 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.ServerSocket;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -62,6 +76,85 @@ public class WavefrontClientTest {
 
   private String createString(int size) {
     return new String(new char[size]).replace("\0", "a");
+  }
+
+  @Nested
+  class WireMockTests {
+    WireMockServer mockBackend;
+
+    @BeforeEach
+    void setup() {
+      mockBackend = new WireMockServer(wireMockConfig().dynamicPort());
+      mockBackend.stubFor(WireMock.post(urlPathMatching("/report")).willReturn(WireMock.ok()));
+      mockBackend.start();
+    }
+
+    @AfterEach
+    void teardown() {
+      mockBackend.stop();
+    }
+
+    @Test
+    void sendMetric() {
+      WavefrontClient wfClient = new WavefrontClient.Builder(mockBackend.baseUrl())
+          .includeSdkMetrics(false)
+          .build();
+      long timestamp = System.currentTimeMillis();
+
+      assertDoesNotThrow(() -> {
+        wfClient.sendMetric("a-name", 1.0, timestamp, "a-source", new HashMap<>());
+        wfClient.flush();
+      });
+
+      String expectedBody = "\"a-name\" 1.0 " + timestamp + " source=\"a-source\"\n";
+      mockBackend.verify(1, postRequestedFor(urlEqualTo("/report?f=wavefront"))
+          .withRequestBody(matching(expectedBody))
+          .withHeader("Content-Type", WireMock.equalTo("application/octet-stream")));
+    }
+
+    @Test
+    void sendSpan() {
+      WavefrontClient wfClient = new WavefrontClient.Builder(mockBackend.baseUrl())
+          .includeSdkMetrics(false)
+          .build();
+      long timestamp = System.currentTimeMillis();
+      UUID traceId = UUID.fromString("01010101-0101-0101-0101-010101010101");
+      UUID spanId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+      assertDoesNotThrow(() -> {
+        wfClient.sendSpan("a-name", timestamp, 1138, "a-source", traceId, spanId,
+            null, null, null, null);
+        wfClient.flush();
+      });
+
+      String expectedBody = "\"a-name\" source=\"a-source\" traceId=" + traceId + " spanId=" +
+          spanId + " " + timestamp + " 1138\n";
+      mockBackend.verify(1, postRequestedFor(urlEqualTo("/report?f=trace"))
+          .withRequestBody(matching(expectedBody))
+          .withHeader("Content-Type", WireMock.equalTo("application/octet-stream")));
+    }
+
+    @Test
+    void sendDistribution() {
+      WavefrontClient wfClient = new WavefrontClient.Builder(mockBackend.baseUrl())
+          .includeSdkMetrics(false)
+          .build();
+      long timestamp = System.currentTimeMillis();
+
+      assertDoesNotThrow(() -> {
+        wfClient.sendDistribution("a-name",
+            Collections.singletonList(new Pair<>(1.1, 2)),
+            Collections.singleton(HistogramGranularity.MINUTE),
+            timestamp, "a-source", null);
+        wfClient.flush();
+      });
+
+      String expectedBody = "!M " + timestamp + " #2 1.1 \"a-name\" source=\"a-source\"\n";
+      mockBackend.verify(1, postRequestedFor(urlEqualTo("/report?f=histogram"))
+          .withRequestBody(matching(expectedBody))
+          .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"))
+      );
+    }
   }
 
   @Nested


### PR DESCRIPTION
Background: we recommend that Distributed Tracing customers have span-level RED metrics computed by sending spans to the Wavefront Proxy's `customTracingListenerPorts` (30001 by default). `WavefrontProxyClient` in this SDK allowed configuring a separate port for spans, but was deprecated in #127.

Until Wavefront Proxy's default listener on port 2878 can also generate span-level RED metrics, we should allow `WavefrontClient` to specify a custom port when sending spans.

Also, backfilled tests for WavefrontClient.