### PR TITLE
Fix the tracing spans section under examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,19 +318,16 @@ wavefrontSender.sendDistribution("request.latency",
 
 #### Tracing Spans
 
+<!-- Commenting this section out for now. We need to uncomment this section after https://github.com/wavefrontHQ/wavefront-sdk-java/pull/201 is published.
 If you are directly using the Sender SDK to send data to Wavefront, you won’t see span-level RED metrics by default unless you use the Wavefront proxy and define a custom tracing port (`tracingPort`). See [Instrument Your Application with Wavefront Sender SDKs](https://docs.wavefront.com/tracing_instrumenting_frameworks.html#instrument-your-application-with-wavefront-sender-sdks) for details.
 
+-->
+
+
 ```java
-// Set up Wavefront Sender for proxy based ingestion
-WavefrontSender wavefrontSender = new WavefrontClient.Builder(proxyHost).
-        tracingPort(30001). // the same port as the customTracingListenerPorts configured in the wavefront proxy
-        metricsPort(metricsPort).
-        distributionPort(distributionPort).
-        messageSizeBytes(messageSizeInBytes).
-        batchSize(batchSize).
-        flushIntervalSeconds(flushIntervalSeconds).
-        maxQueueSize(queueSize).
-        build(); // Returns a WavefrontClient
+// Using the WavefrontClient.Builder directly with a url in the form of "http://your.proxy.load.blanacer:port"
+// to send data to proxies.
+WavefrontClient.Builder wfClientBuilder = new WavefrontClient.Builder(proxyURL);
 
 // Now send distributed tracing spans as below
  // Wavefront tracing span data format


### PR DESCRIPTION
The current example under trace spans was incorrect. I removed the old config and added the new way.

I also commented out the section that asks users to define the custom tracing spans to see span-level-RED metrics. Once https://github.com/wavefrontHQ/wavefront-sdk-java/pull/201 is published. We need to uncomment that section update the example accordingly too. 