### PR TITLE
Unshade guava and t-digest dependencies to release v3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,47 +65,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
-                <executions>
-                  <execution>
-                    <phase>package</phase>
-                    <goals>
-                      <goal>shade</goal>
-                    </goals>
-                    <configuration>
-                        <minimizeJar>true</minimizeJar>
-                        <artifactSet>
-                            <includes>
-                                <include>com.tdunning:t-digest</include>
-                                <include>com.google.guava</include>
-                            </includes>
-                        </artifactSet>
-                        <relocations>
-                            <relocation>
-                                <pattern>com.tdunning.math</pattern>
-                                <shadedPattern>com.wavefront.java_sdk.com.tdunning.math</shadedPattern>
-                            </relocation>
-                            <relocation>
-                                <pattern>com.google</pattern>
-                                <shadedPattern>com.wavefront.java_sdk.com.google</shadedPattern>
-                            </relocation>
-                        </relocations>
-                        <filters>
-                            <filter>
-                                <artifact>*:*</artifact>
-                                <excludes>
-                                    <exclude>META-INF/license/**</exclude>
-                                    <exclude>mozilla/**</exclude>
-                                </excludes>
-                            </filter>
-                        </filters>
-                    </configuration>
-                  </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-sdk-java</artifactId>
-    <version>2.6.7-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
This is a breaking API change, removing the following packages:

- `com.wavefront.java_sdk.com.google`
- `com.wavefront.java_sdk.com.tdunning.math`

As such, it warrants releasing a new major version of this SDK: 3.0.