### PR TITLE
[MONIT-29250] Include stack traces in `run()` methods

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -619,7 +619,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
       this.flush();
     } catch (Throwable ex) {
       logger.log(LogMessageType.FLUSH_ERROR.toString(), Level.WARNING,
-          "Unable to report to Wavefront cluster: " + Throwables.getRootCause(ex));
+          "Unable to report to Wavefront cluster", Throwables.getRootCause(ex));
     }
   }
 

--- a/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
+++ b/src/main/java/com/wavefront/sdk/direct/ingestion/WavefrontDirectIngestionClient.java
@@ -401,7 +401,7 @@ public class WavefrontDirectIngestionClient implements WavefrontSender, Runnable
       this.flush();
     } catch (Throwable ex) {
       logger.log(LogMessageType.FLUSH_ERROR.toString(), Level.WARNING,
-          "Unable to report to Wavefront cluster: " + Throwables.getRootCause(ex));
+          "Unable to report to Wavefront cluster", Throwables.getRootCause(ex));
     }
   }
 


### PR DESCRIPTION
Add support in MessageDepupingLogger to include a Throwable forincluding a stack trace in log output.

Used new logger method in:

- WavefrontClient
- WavefrontDirectIngestionClient
- Already included stack trace: WavefrontProxyClient

**Testing Notes**
Manually tested with test harness app:
```
Sent tracing span: 'getAllUsers' to proxy
Jun 08, 2022 3:48:49 PM com.wavefront.sdk.common.clients.WavefrontClient run
WARNING: Unable to report to Wavefront cluster: 
java.io.IOException: attempt to flush closed sender
	at com.wavefront.sdk.common.clients.WavefrontClient.flush(WavefrontClient.java:632)
	at com.wavefront.sdk.common.clients.WavefrontClient.run(WavefrontClient.java:619)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```