### PR TITLE
Fix _spanSecondaryId for span logs & add fine-level logging

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/Constants.java
+++ b/src/main/java/com/wavefront/sdk/common/Constants.java
@@ -108,6 +108,14 @@ public final class Constants {
   public static final String SPAN_LOG_KEY = "_spanLogs";
 
   /**
+   * Tag key to uniquely identify an OpenZipkin Brave span when combined with Span Id. The tag value
+   * should be the span's kind (e.g. "client", "server", "producer", "consumer"). Should only be
+   * needed in scenarios where Span Id isn't guaranteed to be unique within a Trace (only known
+   * case is OpenZipkin Brave).
+   */
+  public static final String SPAN_SECONDARY_ID_KEY = "_spanSecondaryId";
+
+  /**
    * Tag key for defining a process identifier.
    */
   public static final String PROCESS_TAG_KEY = "pid";

--- a/src/main/java/com/wavefront/sdk/common/Utils.java
+++ b/src/main/java/com/wavefront/sdk/common/Utils.java
@@ -449,8 +449,15 @@ public class Utils {
     return spanLogsToLineData(traceId, spanId, spanLogs, null);
   }
 
-  public static String spanLogsToLineData(UUID traceId, UUID spanId,
-                                          @NonNull List<SpanLog> spanLogs, @Nullable String span)
+  public static String spanLogsToLineData(
+          UUID traceId, UUID spanId, @NonNull List<SpanLog> spanLogs, @Nullable String span)
+      throws JsonProcessingException {
+    return spanLogsToLineData(traceId, spanId, spanLogs, span, null);
+  }
+
+  public static String spanLogsToLineData(
+          UUID traceId, UUID spanId, @NonNull List<SpanLog> spanLogs, @Nullable String span,
+          @Nullable String spanSecondaryId)
       throws JsonProcessingException {
     /*
      * Wavefront Span Log Data format
@@ -468,14 +475,16 @@ public class Utils {
      *                  "stack": "File \"example.py\", line 7, in \<module\>\ncaller()\nFile \"example.py\""
      *              }
      *          }
-     *      ]
+     *      ],
+     *      "span": ""\"GET /oops\" source=\"a-src\" traceId=....",
+     *      "_spanSecondaryId": "server"
      *  }
      */
 
     StringBuilder toReturn = new StringBuilder();
-    toReturn.append(JSON_PARSER.writeValueAsString(new SpanLogsDTO(traceId, spanId, spanLogs,
-        span)));
-    toReturn.append("\n");
+    SpanLogsDTO spanLogsDTO = new SpanLogsDTO(traceId, spanId, spanLogs, span, spanSecondaryId);
+    toReturn.append(JSON_PARSER.writeValueAsString(spanLogsDTO))
+            .append("\n");
     return toReturn.toString();
   }
 

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -443,6 +443,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     try {
       point = metricToLineData(name, value, timestamp, source, tags, defaultSource);
       pointsValid.inc();
+      logger.fine("sendMetric: " + point);
     } catch (IllegalArgumentException e) {
       pointsInvalid.inc();
       throw e;
@@ -466,6 +467,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
       throw new IllegalArgumentException("point must be non-null and in WF data format");
     }
     pointsValid.inc();
+    logger.fine("sendFormattedMetric: " + point);
     String finalPoint = point.endsWith("\n") ? point : point + "\n";
 
     if (!metricsBuffer.offer(finalPoint)) {
@@ -490,6 +492,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
       histograms = histogramToLineData(name, centroids, histogramGranularities, timestamp,
           source, tags, defaultSource);
       histogramsValid.inc();
+      logger.fine("sendDistribution: " + histograms);
     } catch (IllegalArgumentException e) {
       histogramsInvalid.inc();
       throw e;
@@ -514,6 +517,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     try {
       point = logToLineData(name, value, timestamp, source, tags, defaultSource);
       logsValid.inc();
+      logger.fine("sendLog: " + point);
     } catch (IllegalArgumentException e) {
       logsInvalid.inc();
       throw e;
@@ -549,6 +553,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
             defaultSource, true);
       }
       eventsValid.inc();
+      logger.fine("sendEvent: " + event);
     } catch (IllegalArgumentException e) {
       eventsInvalid.inc();
       throw e;
@@ -574,6 +579,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
       span = tracingSpanToLineData(name, startMillis, durationMillis, source, traceId,
           spanId, parents, followsFrom, tags, spanLogs, defaultSource);
       spansValid.inc();
+      logger.fine("sendSpan: " + span);
     } catch (IllegalArgumentException e) {
       spansInvalid.inc();
       throw e;
@@ -606,6 +612,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     try {
       String spanLogsJson = spanLogsToLineData(traceId, spanId, spanLogs, span, spanSecondaryId);
       spanLogsValid.inc();
+      logger.fine("sendSpanLogs: " + spanLogsJson);
       if (!spanLogsBuffer.offer(spanLogsJson)) {
         spanLogsDropped.inc();
         logger.log(LogMessageType.SPANLOGS_BUFFER_FULL.toString(), Level.WARNING,

--- a/src/main/java/com/wavefront/sdk/entities/tracing/SpanLogsDTO.java
+++ b/src/main/java/com/wavefront/sdk/entities/tracing/SpanLogsDTO.java
@@ -1,9 +1,12 @@
 package com.wavefront.sdk.entities.tracing;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.wavefront.sdk.common.annotation.Nullable;
 
 import java.util.List;
 import java.util.UUID;
+
+import static com.wavefront.sdk.common.Constants.SPAN_SECONDARY_ID_KEY;
 
 /**
  * DTO for the spanLogs to be sent to Wavefront.
@@ -19,15 +22,25 @@ public class SpanLogsDTO {
   @Nullable
   private final String span;
 
+  @Nullable
+  private final String spanSecondaryId;
+
   public SpanLogsDTO(UUID traceId, UUID spanId, List<SpanLog> spanLogs) {
     this(traceId, spanId, spanLogs, null);
   }
 
   public SpanLogsDTO(UUID traceId, UUID spanId, List<SpanLog> spanLogs, @Nullable String span) {
+    this(traceId, spanId, spanLogs, span, null);
+  }
+
+  public SpanLogsDTO(
+          UUID traceId, UUID spanId, List<SpanLog> spanLogs, @Nullable String span,
+          @Nullable String spanSecondaryId) {
     this.traceId = traceId;
     this.spanId = spanId;
     this.logs = spanLogs;
     this.span = span;
+    this.spanSecondaryId = spanSecondaryId;
   }
 
   public UUID getTraceId() {
@@ -44,5 +57,10 @@ public class SpanLogsDTO {
 
   public String getSpan() {
     return span;
+  }
+
+  @JsonGetter(SPAN_SECONDARY_ID_KEY)
+  public String getSpanSecondaryId() {
+    return spanSecondaryId;
   }
 }

--- a/src/test/java/com/wavefront/sdk/common/UtilsTest.java
+++ b/src/test/java/com/wavefront/sdk/common/UtilsTest.java
@@ -722,7 +722,7 @@ public class UtilsTest {
     assertEquals("{\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
             "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
             "\"logs\":[{\"timestamp\":91616745187,\"fields\":{\"key1\":\"val1\"}}]," +
-            "\"span\":null}\n",
+            "\"span\":null,\"_spanSecondaryId\":null}\n",
         spanLogsToLineData(UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"),
             UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
             Arrays.asList(new SpanLog(91616745187L,
@@ -733,6 +733,85 @@ public class UtilsTest {
 
   @Test
   public void testSpanLogsToLineDataWithSpan() throws IOException {
+    String actual1 = spanLogsToLineData(
+            UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"),
+            UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
+            Arrays.asList(new SpanLog(91616745187L,
+                                      new HashMap<String, String>() {{
+                                        put("key1", "val1");
+                                      }})),
+            "\"getAllUsers\" source=\"localhost\" " +
+                    "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
+                    "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
+                    "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "\"application\"=\"Wavefront\" " +
+                    "\"http.method\"=\"GET\" 1493773500 343500\n");
+    assertEquals(
+            "{\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
+                    "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
+                    "\"logs\":[{\"timestamp\":91616745187,\"fields\":{\"key1\":\"val1\"}}]," +
+                    "\"span\":\"\\\"getAllUsers\\\" source=\\\"localhost\\\" " +
+                    "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
+                    "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
+                    "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "\\\"application\\\"=\\\"Wavefront\\\" \\\"http.method\\\"=\\\"GET\\\" " +
+                    "1493773500 343500\\n\"," +
+                    "\"_spanSecondaryId\":null" +
+                    "}\n",
+            actual1);
+
+    // source with colon
+    String actual2 = spanLogsToLineData(
+            UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"),
+            UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
+            Arrays.asList(new SpanLog(91616745187L,
+                                      new HashMap<String, String>() {{
+                                        put("key1", "val1");
+                                      }})),
+            "\"getAllUsers\" source=\"localhost:5050\" " +
+                    "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
+                    "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
+                    "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "\"application\"=\"Wavefront\" " +
+                    "\"http.method\"=\"GET\" 1493773500 343500\n");
+
+    assertEquals(
+            "{\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
+                    "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
+                    "\"logs\":[{\"timestamp\":91616745187,\"fields\":{\"key1\":\"val1\"}}]," +
+                    "\"span\":\"\\\"getAllUsers\\\" source=\\\"localhost:5050\\\" " +
+                    "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
+                    "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
+                    "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "\\\"application\\\"=\\\"Wavefront\\\" \\\"http.method\\\"=\\\"GET\\\" " +
+                    "1493773500 343500\\n\"," +
+                    "\"_spanSecondaryId\":null" +
+                    "}\n",
+            actual2);
+  }
+
+  @Test
+  public void testSpanLogsToLineDataWithSpanAndSecondaryId() throws IOException {
+    String actual = spanLogsToLineData(
+            UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"),
+            UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
+            Arrays.asList(new SpanLog(91616745187L,
+                                      new HashMap<String, String>() {{
+                                        put("key1", "val1");
+                                      }})),
+            "\"getAllUsers\" source=\"localhost\" " +
+                    "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
+                    "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
+                    "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
+                    "\"application\"=\"Wavefront\" " +
+                    "\"http.method\"=\"GET\" 1493773500 343500\n",
+            "server");
+
     assertEquals("{\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
             "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
             "\"logs\":[{\"timestamp\":91616745187,\"fields\":{\"key1\":\"val1\"}}]," +
@@ -742,46 +821,10 @@ public class UtilsTest {
               "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
               "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
               "\\\"application\\\"=\\\"Wavefront\\\" \\\"http.method\\\"=\\\"GET\\\" " +
-              "1493773500 343500\\n\"" +
+              "1493773500 343500\\n\"," +
+            "\"_spanSecondaryId\":\"server\"" +
             "}\n",
-        spanLogsToLineData(UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"),
-            UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
-            Arrays.asList(new SpanLog(91616745187L,
-                new HashMap<String, String>() {{
-                  put("key1", "val1");
-                }})),
-            "\"getAllUsers\" source=\"localhost\" " +
-                "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
-                "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
-                "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
-                "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
-                "\"application\"=\"Wavefront\" " +
-                "\"http.method\"=\"GET\" 1493773500 343500\n"));
-    // source with colon
-    assertEquals("{\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
-            "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
-            "\"logs\":[{\"timestamp\":91616745187,\"fields\":{\"key1\":\"val1\"}}]," +
-            "\"span\":\"\\\"getAllUsers\\\" source=\\\"localhost:5050\\\" " +
-            "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
-            "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
-            "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
-            "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
-            "\\\"application\\\"=\\\"Wavefront\\\" \\\"http.method\\\"=\\\"GET\\\" " +
-            "1493773500 343500\\n\"" +
-            "}\n",
-        spanLogsToLineData(UUID.fromString("7b3bf470-9456-11e8-9eb6-529269fb1459"),
-            UUID.fromString("0313bafe-9457-11e8-9eb6-529269fb1459"),
-            Arrays.asList(new SpanLog(91616745187L,
-                new HashMap<String, String>() {{
-                  put("key1", "val1");
-                }})),
-            "\"getAllUsers\" source=\"localhost:5050\" " +
-                "traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 " +
-                "spanId=0313bafe-9457-11e8-9eb6-529269fb1459 " +
-                "parent=2f64e538-9457-11e8-9eb6-529269fb1459 " +
-                "followsFrom=5f64e538-9457-11e8-9eb6-529269fb1459 " +
-                "\"application\"=\"Wavefront\" " +
-                "\"http.method\"=\"GET\" 1493773500 343500\n"));
+                 actual);
   }
 
   @Test


### PR DESCRIPTION
The `_spanSecondaryId` field wasn't included on span logs, meaning that links to span logs in the UI weren't working in certain cases for spring boot apps. I only implemented this feature in `WavefrontClient` (not the deprecated DI and Proxy clients).

Also added FINE-level logging of Wavefront data in`WavefrontClient` when the following methods are invoked:
- sendDistribution
- sendEvent
- sendFormattedMetric
- sendLog
- sendMetric
- sendSpan
- sendSpanLogs