### PR TITLE
Improve log messages from `ReportingService`

### DIFF
--- a/src/main/java/com/wavefront/sdk/Main.java
+++ b/src/main/java/com/wavefront/sdk/Main.java
@@ -2,6 +2,7 @@ package com.wavefront.sdk;
 
 import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.clients.WavefrontClient;
 import com.wavefront.sdk.common.clients.WavefrontClientFactory;
 import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
 import com.wavefront.sdk.entities.histograms.HistogramGranularity;
@@ -119,8 +120,11 @@ public class Main {
             token + "@" + wavefrontServer.substring(wavefrontServer.indexOf("://")+3);
     System.out.println("wavefrontServerWithToken = " + wavefrontServerWithToken);
 
+    WavefrontClient.Builder wfClientBuilder = new WavefrontClient.Builder(wavefrontServer, token);
+    WavefrontSender wavefrontSender = wfClientBuilder.build();
+
     WavefrontClientFactory wavefrontClientFactory = new WavefrontClientFactory();
-    wavefrontClientFactory.addClient(wavefrontServerWithToken);
+    wavefrontClientFactory.addClient(wavefrontSender);
 
     // DEPRECATED Client: Direct Data Ingestion
 //    WavefrontDirectIngestionClient wavefrontDirectIngestionClient =

--- a/src/main/java/com/wavefront/sdk/Main.java
+++ b/src/main/java/com/wavefront/sdk/Main.java
@@ -2,7 +2,6 @@ package com.wavefront.sdk;
 
 import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.WavefrontSender;
-import com.wavefront.sdk.common.clients.WavefrontClient;
 import com.wavefront.sdk.common.clients.WavefrontClientFactory;
 import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
 import com.wavefront.sdk.entities.histograms.HistogramGranularity;
@@ -120,11 +119,8 @@ public class Main {
             token + "@" + wavefrontServer.substring(wavefrontServer.indexOf("://")+3);
     System.out.println("wavefrontServerWithToken = " + wavefrontServerWithToken);
 
-    WavefrontClient.Builder wfClientBuilder = new WavefrontClient.Builder(wavefrontServer, token);
-    WavefrontSender wavefrontSender = wfClientBuilder.build();
-
     WavefrontClientFactory wavefrontClientFactory = new WavefrontClientFactory();
-    wavefrontClientFactory.addClient(wavefrontSender);
+    wavefrontClientFactory.addClient(wavefrontServerWithToken);
 
     // DEPRECATED Client: Direct Data Ingestion
 //    WavefrontDirectIngestionClient wavefrontDirectIngestionClient =

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -146,7 +146,6 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     private int tracesPort = -1;
     private int maxQueueSize = 500000;
     private int batchSize = 10000;
-    private long reportingServiceLogSuppressTimeSeconds = 300;
     private long flushInterval = 1;
     private TimeUnit flushIntervalTimeUnit = TimeUnit.SECONDS;
     private int messageSizeBytes = Integer.MAX_VALUE;
@@ -196,17 +195,6 @@ public class WavefrontClient implements WavefrontSender, Runnable {
      */
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
-      return this;
-    }
-
-    /**
-     * Set the reportingService log suppression time in seconds. The logs will be suppressed until this time elapses.
-     *
-     * @param reportingServiceLogSuppressTimeSeconds
-     * @return {@code this}
-     */
-    public Builder reportingServiceLogSuppressTimeSeconds(long reportingServiceLogSuppressTimeSeconds) {
-      this.reportingServiceLogSuppressTimeSeconds = reportingServiceLogSuppressTimeSeconds;
       return this;
     }
 
@@ -366,8 +354,8 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     spanLogsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
     eventsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
     logsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
-    metricsReportingService = new ReportingService(builder.metricsUri, builder.token, builder.reportingServiceLogSuppressTimeSeconds);
-    tracesReportingService = new ReportingService(builder.tracesUri, builder.token, builder.reportingServiceLogSuppressTimeSeconds);
+    metricsReportingService = new ReportingService(builder.metricsUri, builder.token);
+    tracesReportingService = new ReportingService(builder.tracesUri, builder.token);
     scheduler = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("wavefrontClientSender").setDaemon(true));
     scheduler.scheduleAtFixedRate(this, 1, builder.flushInterval, builder.flushIntervalTimeUnit);

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -146,6 +146,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     private int tracesPort = -1;
     private int maxQueueSize = 500000;
     private int batchSize = 10000;
+    private long reportingServiceLogSuppressTimeSeconds = 300;
     private long flushInterval = 1;
     private TimeUnit flushIntervalTimeUnit = TimeUnit.SECONDS;
     private int messageSizeBytes = Integer.MAX_VALUE;
@@ -195,6 +196,17 @@ public class WavefrontClient implements WavefrontSender, Runnable {
      */
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
+      return this;
+    }
+
+    /**
+     * Set the reportingService log suppression time in seconds. The logs will be suppressed until this time elapses.
+     *
+     * @param reportingServiceLogSuppressTimeSeconds
+     * @return {@code this}
+     */
+    public Builder reportingServiceLogSuppressTimeSeconds(long reportingServiceLogSuppressTimeSeconds) {
+      this.reportingServiceLogSuppressTimeSeconds = reportingServiceLogSuppressTimeSeconds;
       return this;
     }
 
@@ -354,8 +366,8 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     spanLogsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
     eventsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
     logsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
-    metricsReportingService = new ReportingService(builder.metricsUri, builder.token);
-    tracesReportingService = new ReportingService(builder.tracesUri, builder.token);
+    metricsReportingService = new ReportingService(builder.metricsUri, builder.token, builder.reportingServiceLogSuppressTimeSeconds);
+    tracesReportingService = new ReportingService(builder.tracesUri, builder.token, builder.reportingServiceLogSuppressTimeSeconds);
     scheduler = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("wavefrontClientSender").setDaemon(true));
     scheduler.scheduleAtFixedRate(this, 1, builder.flushInterval, builder.flushIntervalTimeUnit);

--- a/src/main/java/com/wavefront/sdk/common/clients/service/ReportingService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/ReportingService.java
@@ -133,7 +133,7 @@ public class ReportingService implements ReportAPI {
     } catch (IOException ex) {
       MESSAGE_SUPPRESSING_LOGGER.log(urlConn.getURL().toString(), Level.SEVERE,
           "Unable to obtain status code from the Wavefront service at "
-              + urlConn.getURL().toString() + " due to: " + ex.getMessage());
+              + urlConn.getURL().toString() + " due to: " + ex);
       statusCode = NO_HTTP_RESPONSE;
     }
 
@@ -142,7 +142,7 @@ public class ReportingService implements ReportAPI {
     } catch (IOException ex) {
       MESSAGE_SUPPRESSING_LOGGER.log(urlConn.getURL().toString(), Level.SEVERE,
           "Unable to read and close error stream from the Wavefront service at "
-              + urlConn.getURL().toString() + " due to: " + ex.getMessage());
+              + urlConn.getURL().toString() + " due to: " + ex);
     }
 
     return statusCode;


### PR DESCRIPTION
 When using just `ex.getMessage()` the error message would look like:

>  Unable to obtain status code from the Wavefront service at http://foo.bar/report?f=trace due to: foo.bar

Without the exception's class name it can be hard to know the real error. Now it looks like:

>  Unable to obtain status code from the Wavefront service at http://foo.bar/report?f=trace due to: java.net.UnknownHostException: foo.bar

Also, some small improvements to the Main.java demo so not include the deprecated WavefrontSenders.