### PR TITLE
Make suppressing logger configurable for ReportingService

### DIFF
--- a/src/main/java/com/wavefront/sdk/Main.java
+++ b/src/main/java/com/wavefront/sdk/Main.java
@@ -2,6 +2,7 @@ package com.wavefront.sdk;
 
 import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.clients.WavefrontClient;
 import com.wavefront.sdk.common.clients.WavefrontClientFactory;
 import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
 import com.wavefront.sdk.entities.histograms.HistogramGranularity;
@@ -119,8 +120,11 @@ public class Main {
             token + "@" + wavefrontServer.substring(wavefrontServer.indexOf("://")+3);
     System.out.println("wavefrontServerWithToken = " + wavefrontServerWithToken);
 
+    WavefrontClient.Builder wfClientBuilder = new WavefrontClient.Builder(wavefrontServer, token);
+    WavefrontSender wavefrontSender = wfClientBuilder.build();
+
     WavefrontClientFactory wavefrontClientFactory = new WavefrontClientFactory();
-    wavefrontClientFactory.addClient(wavefrontServerWithToken);
+    wavefrontClientFactory.addClient(wavefrontSender);
 
     // DEPRECATED Client: Direct Data Ingestion
 //    WavefrontDirectIngestionClient wavefrontDirectIngestionClient =

--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -146,6 +146,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     private int tracesPort = -1;
     private int maxQueueSize = 500000;
     private int batchSize = 10000;
+    private long reportingServiceLogSuppressTimeSeconds = 300;
     private long flushInterval = 1;
     private TimeUnit flushIntervalTimeUnit = TimeUnit.SECONDS;
     private int messageSizeBytes = Integer.MAX_VALUE;
@@ -195,6 +196,17 @@ public class WavefrontClient implements WavefrontSender, Runnable {
      */
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
+      return this;
+    }
+
+    /**
+     * Set the reportingService log suppression time in seconds. The logs will be suppressed until this time elapses.
+     *
+     * @param reportingServiceLogSuppressTimeSeconds
+     * @return {@code this}
+     */
+    public Builder reportingServiceLogSuppressTimeSeconds(long reportingServiceLogSuppressTimeSeconds) {
+      this.reportingServiceLogSuppressTimeSeconds = reportingServiceLogSuppressTimeSeconds;
       return this;
     }
 
@@ -354,8 +366,8 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     spanLogsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
     eventsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
     logsBuffer = new LinkedBlockingQueue<>(builder.maxQueueSize);
-    metricsReportingService = new ReportingService(builder.metricsUri, builder.token);
-    tracesReportingService = new ReportingService(builder.tracesUri, builder.token);
+    metricsReportingService = new ReportingService(builder.metricsUri, builder.token, builder.reportingServiceLogSuppressTimeSeconds);
+    tracesReportingService = new ReportingService(builder.tracesUri, builder.token, builder.reportingServiceLogSuppressTimeSeconds);
     scheduler = Executors.newScheduledThreadPool(1,
         new NamedThreadFactory("wavefrontClientSender").setDaemon(true));
     scheduler.scheduleAtFixedRate(this, 1, builder.flushInterval, builder.flushIntervalTimeUnit);


### PR DESCRIPTION
Use `WavefrontClient.Builder#reportingServiceLogSuppressTimeSeconds()`

Fixes https://github.com/wavefrontHQ/wavefront-sdk-java/issues/206

Co-authored by : Glenn Oppegard <goppegard@vmware.com>