### PR TITLE
Revert "Bump maven-javadoc-plugin from 3.4.1 to 3.5.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.4.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
Reverts wavefrontHQ/wavefront-sdk-java#260

It causes the release process for v3.2.0 of the SDK to fail in Jenkins.