### PR TITLE
Single `WavefrontClient.Builder` constructor to specify any auth type

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/WavefrontClient.java
@@ -163,7 +163,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
     // Optional parameters
     private int metricsPort = -1;
     private int tracesPort = -1;
-    private int maxQueueSize = 500_000;
+    private int maxQueueSize = 50_000;
     private int batchSize = 10_000;
     private long reportingServiceLogSuppressTimeSeconds = 300;
     private long flushInterval = 1;
@@ -859,7 +859,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
         switch (featureDisabledReason) {
           case 401:
             logger.log(permissionsMessageType.toString(), Level.SEVERE,
-                "Please verify that your " + tokenService.getType() + " credential(s) are correct! All " + entityType + " will be " +
+                "Please verify that your credentials are correct! All " + entityType + " will be " +
                     "discarded until the service is restarted.");
             break;
           case 403:
@@ -888,8 +888,8 @@ public class WavefrontClient implements WavefrontSender, Runnable {
           switch (statusCode) {
             case 401:
               logger.log(permissionsMessageType.toString(), Level.SEVERE,
-                  "Error sending " + entityType + " to Wavefront (HTTP " + statusCode + "). " +
-                      "Please verify that your " + tokenService.getType() + " is correct! All " + entityType + " will " +
+                  "Error sending " + entityType + " to Wavefront (HTTP 401 Unauthorized). " +
+                      "Please verify that your credentials are correct! All " + entityType + " will " +
                       "be discarded until the service is restarted.");
               featureDisabledStatusCode.set(statusCode);
               dropped.inc(items.size());
@@ -897,7 +897,7 @@ public class WavefrontClient implements WavefrontSender, Runnable {
             case 403:
               if (format.equals(Constants.WAVEFRONT_METRIC_FORMAT)) {
                 logger.log(permissionsMessageType.toString(), Level.SEVERE,
-                    "Error sending " + entityType + " to Wavefront (HTTP " + statusCode + "). " +
+                    "Error sending " + entityType + " to Wavefront (HTTP 403 Forbidden). " +
                         "Please verify that Direct Data Ingestion is enabled for your account! " +
                         "All " + entityType + " will be discarded until the service is restarted.");
               } else {

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPTokenService.java
@@ -43,8 +43,8 @@ public class CSPTokenService implements TokenService, Runnable {
   }
 
   @Override
-  public String getType() {
-    return cspUrlConnectionFactory.getType();
+  public Type getType() {
+    return cspUrlConnectionFactory.getTokenType();
   }
 
   public synchronized void run() {

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPTokenService.java
@@ -8,14 +8,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 public class CSPTokenService implements TokenService, Runnable {
   private static final String INVALID_TOKEN = "INVALID_TOKEN";
@@ -68,7 +65,7 @@ public class CSPTokenService implements TokenService, Runnable {
 
           // Schedule token refresh in the future
           Duration threadDelay = getThreadDelay(parsedResponse.expiresIn);
-          log.info("A CSP token was received. The token will be refreshed in " + threadDelay.getSeconds() + " seconds.");
+          log.info("Received CSP token and will refresh in " + threadDelay.getSeconds() + " seconds.");
           executor.schedule(this, threadDelay.getSeconds(), TimeUnit.SECONDS);
 
           return parsedResponse.accessToken;
@@ -78,7 +75,7 @@ public class CSPTokenService implements TokenService, Runnable {
           return INVALID_TOKEN;
         }
       } else {
-        log.severe("The request to CSP for a token failed with HTTP code " + statusCode + ".");
+        log.severe("The request to CSP for a token failed with HTTP " + statusCode + ".");
 
         if (statusCode >= 500 && statusCode < 600) {
           log.info("The Wavefront SDK will try to reauthenticate with CSP on the next request.");
@@ -116,9 +113,5 @@ public class CSPTokenService implements TokenService, Runnable {
     }
 
     return delay;
-  }
-
-  private static List<String> parseScopes(final String scope) {
-    return Arrays.stream(scope.split("\\s")).collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPTokenService.java
@@ -3,7 +3,6 @@ package com.wavefront.sdk.common.clients.service.token;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wavefront.sdk.common.NamedThreadFactory;
-import com.wavefront.sdk.common.Utils;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPURLConnectionFactory.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPURLConnectionFactory.java
@@ -1,14 +1,25 @@
 package com.wavefront.sdk.common.clients.service.token;
 
+import com.wavefront.sdk.common.Utils;
+import com.wavefront.sdk.common.annotation.Nullable;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 
-public interface CSPURLConnectionFactory {
-  String DEFAULT_BASE_URL = "https://console.cloud.vmware.com/";
+public abstract class CSPURLConnectionFactory {
+  protected String cspBaseURL = "https://console.cloud.vmware.com";
+  protected int connectTimeoutMillis = 30_000;
+  protected int readTimeoutMillis = 10_000;
 
-  HttpURLConnection build() throws IOException;
+  public CSPURLConnectionFactory(@Nullable String cspBaseURL) {
+    if (!Utils.isNullOrEmpty(cspBaseURL)) {
+      this.cspBaseURL = cspBaseURL;
+    }
+  }
 
-  byte[] getPostData();
+  public abstract HttpURLConnection build() throws IOException;
 
-  String getType();
+  public abstract byte[] getPostData();
+
+  public abstract TokenService.Type getTokenType();
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPURLConnectionFactory.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPURLConnectionFactory.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 
 public interface CSPURLConnectionFactory {
+  String DEFAULT_BASE_URL = "https://console.cloud.vmware.com/";
+
   HttpURLConnection build() throws IOException;
 
   byte[] getPostData();

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPUserTokenURLConnectionFactory.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPUserTokenURLConnectionFactory.java
@@ -1,5 +1,8 @@
 package com.wavefront.sdk.common.clients.service.token;
 
+import com.wavefront.sdk.common.Utils;
+import com.wavefront.sdk.common.annotation.Nullable;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -7,15 +10,15 @@ import java.nio.charset.StandardCharsets;
 
 public class CSPUserTokenURLConnectionFactory implements CSPURLConnectionFactory {
   private final static String OAUTH_PATH = "/csp/gateway/am/api/auth/api-tokens/authorize";
-  private final static String TYPE = "CSP API TOKEN";
+  private final static String TYPE = "CSP API Token";
 
   private final String cspBaseURL;
   private final byte[] postData;
   private int connectTimeoutMillis = 30_000;
   private int readTimeoutMillis = 10_000;
 
-  public CSPUserTokenURLConnectionFactory(String cspBaseURL, String apiToken) {
-    this.cspBaseURL = cspBaseURL;
+  public CSPUserTokenURLConnectionFactory(@Nullable String cspBaseURL, String apiToken) {
+    this.cspBaseURL = Utils.isNullOrEmpty(cspBaseURL) ? DEFAULT_BASE_URL : cspBaseURL;
     this.postData = ("grant_type=api_token&refresh_token=" + apiToken).getBytes(StandardCharsets.UTF_8);
   }
 

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPUserTokenURLConnectionFactory.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/CSPUserTokenURLConnectionFactory.java
@@ -1,6 +1,5 @@
 package com.wavefront.sdk.common.clients.service.token;
 
-import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.common.annotation.Nullable;
 
 import java.io.IOException;
@@ -8,21 +7,16 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-public class CSPUserTokenURLConnectionFactory implements CSPURLConnectionFactory {
+public class CSPUserTokenURLConnectionFactory extends CSPURLConnectionFactory {
   private final static String OAUTH_PATH = "/csp/gateway/am/api/auth/api-tokens/authorize";
-  private final static String TYPE = "CSP API Token";
-
-  private final String cspBaseURL;
   private final byte[] postData;
-  private int connectTimeoutMillis = 30_000;
-  private int readTimeoutMillis = 10_000;
 
   public CSPUserTokenURLConnectionFactory(@Nullable String cspBaseURL, String apiToken) {
-    this.cspBaseURL = Utils.isNullOrEmpty(cspBaseURL) ? DEFAULT_BASE_URL : cspBaseURL;
+    super(cspBaseURL);
     this.postData = ("grant_type=api_token&refresh_token=" + apiToken).getBytes(StandardCharsets.UTF_8);
   }
 
-  public CSPUserTokenURLConnectionFactory(String cspBaseURL, String apiToken, int connectTimeoutMillis, int readTimeoutMillis) {
+  public CSPUserTokenURLConnectionFactory(@Nullable String cspBaseURL, String apiToken, int connectTimeoutMillis, int readTimeoutMillis) {
     this(cspBaseURL, apiToken);
     this.connectTimeoutMillis = connectTimeoutMillis;
     this.readTimeoutMillis = readTimeoutMillis;
@@ -49,5 +43,7 @@ public class CSPUserTokenURLConnectionFactory implements CSPURLConnectionFactory
   }
 
   @Override
-  public String getType() { return TYPE; }
+  public TokenService.Type getTokenType() {
+    return TokenService.Type.CSP_API_TOKEN;
+  }
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/NoopProxyTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/NoopProxyTokenService.java
@@ -13,6 +13,6 @@ public class NoopProxyTokenService implements TokenService {
 
   @Override
   public String getType() {
-    return "PROXY";
+    return "No-Op/Proxy";
   }
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/NoopProxyTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/NoopProxyTokenService.java
@@ -12,7 +12,7 @@ public class NoopProxyTokenService implements TokenService {
   }
 
   @Override
-  public String getType() {
-    return "No-Op/Proxy";
+  public Type getType() {
+    return Type.NO_TOKEN;
   }
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenService.java
@@ -2,5 +2,23 @@ package com.wavefront.sdk.common.clients.service.token;
 
 public interface TokenService {
   String getToken();
-  String getType();
+  Type getType();
+
+  enum Type {
+    NO_TOKEN("No-Op/Proxy"),
+    WAVEFRONT_API_TOKEN("Wavefront API Token"),
+    CSP_API_TOKEN("CSP API Token"),
+    CSP_CLIENT_CREDENTIALS("CSP Client Credentials");
+
+    private final String type;
+
+    Type(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public String toString() {
+      return type;
+    }
+  }
 }

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenServiceFactory.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenServiceFactory.java
@@ -1,0 +1,21 @@
+package com.wavefront.sdk.common.clients.service.token;
+
+import com.wavefront.sdk.common.annotation.Nullable;
+
+public class TokenServiceFactory {
+  public static TokenService create(TokenService.Type type, String token, @Nullable String cspBaseURL) {
+    switch (type) {
+      case CSP_API_TOKEN:
+        return new CSPTokenService(new CSPUserTokenURLConnectionFactory(cspBaseURL, token));
+      case CSP_CLIENT_CREDENTIALS:
+        return new CSPTokenService(new CSPServerTokenURLConnectionFactory(token));
+      case WAVEFRONT_API_TOKEN:
+        return new WavefrontTokenService(token);
+      case NO_TOKEN:
+        return new NoopProxyTokenService();
+      default:
+        return new NoopProxyTokenService();
+    }
+  }
+
+}

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenType.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenType.java
@@ -1,0 +1,5 @@
+package com.wavefront.sdk.common.clients.service.token;
+
+public enum TokenType {
+  NO_TOKEN, WAVEFRONT_API_TOKEN, CSP_API_TOKEN, CSP_CLIENT_CREDENTIALS
+}

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenType.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/TokenType.java
@@ -1,5 +1,0 @@
-package com.wavefront.sdk.common.clients.service.token;
-
-public enum TokenType {
-  NO_TOKEN, WAVEFRONT_API_TOKEN, CSP_API_TOKEN, CSP_CLIENT_CREDENTIALS
-}

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/WavefrontTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/WavefrontTokenService.java
@@ -2,7 +2,7 @@ package com.wavefront.sdk.common.clients.service.token;
 
 public class WavefrontTokenService implements TokenService {
   private final String token;
-  private final String type = "WAVEFRONT API TOKEN";
+  private final String type = "Wavefront API Token";
 
   public WavefrontTokenService(final String token) {
     this.token = token;

--- a/src/main/java/com/wavefront/sdk/common/clients/service/token/WavefrontTokenService.java
+++ b/src/main/java/com/wavefront/sdk/common/clients/service/token/WavefrontTokenService.java
@@ -2,7 +2,7 @@ package com.wavefront.sdk.common.clients.service.token;
 
 public class WavefrontTokenService implements TokenService {
   private final String token;
-  private final String type = "Wavefront API Token";
+  private final Type type = Type.WAVEFRONT_API_TOKEN;
 
   public WavefrontTokenService(final String token) {
     this.token = token;
@@ -14,5 +14,5 @@ public class WavefrontTokenService implements TokenService {
   }
 
   @Override
-  public String getType() {  return type;  }
+  public Type getType() {  return type;  }
 }

--- a/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientTest.java
@@ -33,10 +33,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static com.wavefront.sdk.common.clients.service.token.TokenType.CSP_API_TOKEN;
-import static com.wavefront.sdk.common.clients.service.token.TokenType.CSP_CLIENT_CREDENTIALS;
-import static com.wavefront.sdk.common.clients.service.token.TokenType.NO_TOKEN;
-import static com.wavefront.sdk.common.clients.service.token.TokenType.WAVEFRONT_API_TOKEN;
+import static com.wavefront.sdk.common.clients.service.token.TokenService.Type.CSP_API_TOKEN;
+import static com.wavefront.sdk.common.clients.service.token.TokenService.Type.CSP_CLIENT_CREDENTIALS;
+import static com.wavefront.sdk.common.clients.service.token.TokenService.Type.NO_TOKEN;
+import static com.wavefront.sdk.common.clients.service.token.TokenService.Type.WAVEFRONT_API_TOKEN;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -252,20 +252,19 @@ public class WavefrontClientTest {
 
     @Test
     public void canSpecifyTokenServiceByEnum() {
-      WavefrontClient wfClient = new WavefrontClient.Builder("", WAVEFRONT_API_TOKEN, "a-token")
-          .build();
+      WavefrontClient wfClient = new WavefrontClient.Builder("", WAVEFRONT_API_TOKEN, "a-token").build();
       assertEquals(WavefrontTokenService.class, wfClient.getTokenService().getClass());
 
-      wfClient = new WavefrontClient.Builder("", NO_TOKEN, "a-token").build();
+      wfClient = new WavefrontClient.Builder("", NO_TOKEN, null).build();
       assertEquals(NoopProxyTokenService.class, wfClient.getTokenService().getClass());
 
       wfClient = new WavefrontClient.Builder("", CSP_API_TOKEN, "a-token").build();
       assertEquals(CSPTokenService.class, wfClient.getTokenService().getClass());
-      assertEquals("CSP API TOKEN", wfClient.getTokenService().getType());
+      assertEquals(CSP_API_TOKEN, wfClient.getTokenService().getType());
 
       wfClient = new WavefrontClient.Builder("", CSP_CLIENT_CREDENTIALS, "clientId=foo,clientSecret=Bar").build();
       assertEquals(CSPTokenService.class, wfClient.getTokenService().getClass());
-      assertEquals("CSP API TOKEN", wfClient.getTokenService().getType());
+      assertEquals(CSP_CLIENT_CREDENTIALS, wfClient.getTokenService().getType());
     }
 
     @Nested

--- a/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/WavefrontClientTest.java
@@ -33,6 +33,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.wavefront.sdk.common.clients.service.token.TokenType.CSP_API_TOKEN;
+import static com.wavefront.sdk.common.clients.service.token.TokenType.CSP_CLIENT_CREDENTIALS;
+import static com.wavefront.sdk.common.clients.service.token.TokenType.NO_TOKEN;
+import static com.wavefront.sdk.common.clients.service.token.TokenType.WAVEFRONT_API_TOKEN;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -232,30 +236,36 @@ public class WavefrontClientTest {
   class Builder {
 
     @Test
-    public void tokenServiceClassTest() {
-      WavefrontClient wfClient = new WavefrontClient.Builder("", "TOKEN")
-              .build();
-      assertNotNull(wfClient);
-      assertNotNull(wfClient.getTokenService());
-      assertEquals(WavefrontTokenService.class.getSimpleName(), wfClient.getTokenService().getClass().getSimpleName());
+    public void choosesTokenServiceBasedOnCreds() {
+      WavefrontClient wfClient = new WavefrontClient.Builder("", "TOKEN").build();
+      assertEquals(WavefrontTokenService.class, wfClient.getTokenService().getClass());
 
-      wfClient = new WavefrontClient.Builder("")
-              .build();
-      assertNotNull(wfClient);
-      assertNotNull(wfClient.getTokenService());
-      assertEquals(NoopProxyTokenService.class.getSimpleName(), wfClient.getTokenService().getClass().getSimpleName());
+      wfClient = new WavefrontClient.Builder("").build();
+      assertEquals(NoopProxyTokenService.class, wfClient.getTokenService().getClass());
 
-      wfClient = new WavefrontClient.Builder("", "cspClientId", "cspClientSecret")
-              .build();
-      assertNotNull(wfClient);
-      assertNotNull(wfClient.getTokenService());
-      assertEquals(CSPTokenService.class.getSimpleName(), wfClient.getTokenService().getClass().getSimpleName());
+      wfClient = new WavefrontClient.Builder("", "cspClientId", "cspClientSecret").build();
+      assertEquals(CSPTokenService.class, wfClient.getTokenService().getClass());
 
-      wfClient = new WavefrontClient.Builder("", "TOKEN")
-              .useTokenForCSP().build();
-      assertNotNull(wfClient);
-      assertNotNull(wfClient.getTokenService());
-      assertEquals(CSPTokenService.class.getSimpleName(), wfClient.getTokenService().getClass().getSimpleName());
+      wfClient = new WavefrontClient.Builder("", "TOKEN").useTokenForCSP().build();
+      assertEquals(CSPTokenService.class, wfClient.getTokenService().getClass());
+    }
+
+    @Test
+    public void canSpecifyTokenServiceByEnum() {
+      WavefrontClient wfClient = new WavefrontClient.Builder("", WAVEFRONT_API_TOKEN, "a-token")
+          .build();
+      assertEquals(WavefrontTokenService.class, wfClient.getTokenService().getClass());
+
+      wfClient = new WavefrontClient.Builder("", NO_TOKEN, "a-token").build();
+      assertEquals(NoopProxyTokenService.class, wfClient.getTokenService().getClass());
+
+      wfClient = new WavefrontClient.Builder("", CSP_API_TOKEN, "a-token").build();
+      assertEquals(CSPTokenService.class, wfClient.getTokenService().getClass());
+      assertEquals("CSP API TOKEN", wfClient.getTokenService().getType());
+
+      wfClient = new WavefrontClient.Builder("", CSP_CLIENT_CREDENTIALS, "clientId=foo,clientSecret=Bar").build();
+      assertEquals(CSPTokenService.class, wfClient.getTokenService().getClass());
+      assertEquals("CSP API TOKEN", wfClient.getTokenService().getType());
     }
 
     @Nested

--- a/src/test/java/com/wavefront/sdk/common/clients/service/CSPTokenServiceTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/service/CSPTokenServiceTest.java
@@ -25,7 +25,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/com/wavefront/sdk/common/clients/service/token/CSPServerTokenURLConnectionFactoryTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/service/token/CSPServerTokenURLConnectionFactoryTest.java
@@ -11,37 +11,42 @@ class CSPServerTokenURLConnectionFactoryTest {
 
   @Test
   void parseClientCredentials() {
-    Map<String, String> creds;
+    Map<CSPServerTokenURLConnectionFactory.CredentialPart, String> subject;
 
-    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc");
-    assertEquals("cid", creds.get("clientId"));
-    assertEquals("csc", creds.get("clientSecret"));
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
 
-    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc,orgId=oid");
-    assertEquals("cid", creds.get("clientId"));
-    assertEquals("csc", creds.get("clientSecret"));
-    assertEquals("oid", creds.get("orgId"));
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc,orgId=oid");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
+    assertEquals("oid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.ORG_ID));
   }
 
   @Test
   void parseClientCredentialsWithOddInput() {
-    Map<String, String> creds;
+    Map<CSPServerTokenURLConnectionFactory.CredentialPart, String> subject;
+
+    // quotes
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=\"cid\",clientSecret='csc'");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
 
     // whitespace
-    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid, clientSecret=csc");
-    assertEquals("cid", creds.get("clientId"));
-    assertEquals("csc", creds.get("clientSecret"));
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid, clientSecret=csc");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
 
     // out of order
-    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("orgId=oid,clientSecret=csc,clientId=cid");
-    assertEquals("cid", creds.get("clientId"));
-    assertEquals("csc", creds.get("clientSecret"));
-    assertEquals("oid", creds.get("orgId"));
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("orgId=oid,clientSecret=csc,clientId=cid");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
+    assertEquals("oid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.ORG_ID));
 
     // case-insensitive
-    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientid=cid,clientSecret=csc");
-    assertEquals("cid", creds.get("clientId"));
-    assertEquals("csc", creds.get("clientSecret"));
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientid=cid,clientSecret=csc");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
   }
 
   @Test

--- a/src/test/java/com/wavefront/sdk/common/clients/service/token/CSPServerTokenURLConnectionFactoryTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/service/token/CSPServerTokenURLConnectionFactoryTest.java
@@ -21,6 +21,17 @@ class CSPServerTokenURLConnectionFactoryTest {
     assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
     assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
     assertEquals("oid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.ORG_ID));
+
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc,baseUrl=https://csp-dev.vmware.com");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
+    assertEquals("https://csp-dev.vmware.com", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.BASE_URL));
+
+    subject = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc,orgId=oid,baseUrl=https://csp-dev.vmware.com");
+    assertEquals("cid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_ID));
+    assertEquals("csc", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.CLIENT_SECRET));
+    assertEquals("oid", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.ORG_ID));
+    assertEquals("https://csp-dev.vmware.com", subject.get(CSPServerTokenURLConnectionFactory.CredentialPart.BASE_URL));
   }
 
   @Test

--- a/src/test/java/com/wavefront/sdk/common/clients/service/token/CSPServerTokenURLConnectionFactoryTest.java
+++ b/src/test/java/com/wavefront/sdk/common/clients/service/token/CSPServerTokenURLConnectionFactoryTest.java
@@ -1,0 +1,61 @@
+package com.wavefront.sdk.common.clients.service.token;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CSPServerTokenURLConnectionFactoryTest {
+
+  @Test
+  void parseClientCredentials() {
+    Map<String, String> creds;
+
+    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc");
+    assertEquals("cid", creds.get("clientId"));
+    assertEquals("csc", creds.get("clientSecret"));
+
+    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid,clientSecret=csc,orgId=oid");
+    assertEquals("cid", creds.get("clientId"));
+    assertEquals("csc", creds.get("clientSecret"));
+    assertEquals("oid", creds.get("orgId"));
+  }
+
+  @Test
+  void parseClientCredentialsWithOddInput() {
+    Map<String, String> creds;
+
+    // whitespace
+    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=cid, clientSecret=csc");
+    assertEquals("cid", creds.get("clientId"));
+    assertEquals("csc", creds.get("clientSecret"));
+
+    // out of order
+    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("orgId=oid,clientSecret=csc,clientId=cid");
+    assertEquals("cid", creds.get("clientId"));
+    assertEquals("csc", creds.get("clientSecret"));
+    assertEquals("oid", creds.get("orgId"));
+
+    // case-insensitive
+    creds = CSPServerTokenURLConnectionFactory.parseClientCredentials("clientid=cid,clientSecret=csc");
+    assertEquals("cid", creds.get("clientId"));
+    assertEquals("csc", creds.get("clientSecret"));
+  }
+
+  @Test
+  void parseClientCredentialsThrowsOnBadInput() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=foo"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=foo,clientSecret=Bar,orgId=org,extra=bad"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=,clientSecret=Bar"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> CSPServerTokenURLConnectionFactory.parseClientCredentials("clientId=foo,clientSecret=Bar,orgId="));
+  }
+}


### PR DESCRIPTION
A new constructor for clearly choosing the type of authentication desired when creating a `WavefrontClient`:

`public Builder(String server, TokenService.Type tokenType, String multiPartToken)`

Examples of the four support authentication types:

**Proxy**
```java
WavefrontClient.Builder("http://wf-proxy.local:2878",
    TokenService.Type.NO_TOKEN,
    null)
```

**Wavefront API Token**
```java
WavefrontClient.Builder("https://surf.wavefront.com",
    TokenService.Type.WAVEFRONT_API_TOKEN,
    "<wf-api-token-guid>")
```

**CSP Client Credentials**
```java
WavefrontClient.Builder("https://surf.wavefront.com",
    TokenService.Type.CSP_CLIENT_CREDENTIALS,
    "clientId=<client-id>,clientSecret=<secret>,orgId=<optional-org-id>")
```

**CSP User API Token**
```java
WavefrontClient.Builder("https://surf.wavefront.com",
    TokenService.Type.CSP_API_TOKEN,
    "<csp-user-api-token>")
```

This feature is to unblock https://github.com/micrometer-metrics/micrometer/issues/4054 and https://github.com/spring-projects/spring-boot/issues/37165.

**Other Notes**

- Fixed a bug where `maxQueueSize` was incorrectly defaulted to 500,000. It is now 50,000 and matches our README as well as the same default used in wavefront-sdk and wavefront-sdk-python.
- Removed `cspBaseUrl` parameter from constructors of `WavefrontClienter.Builder`. Overridding the Production CSP URL can be done with the existing the `cspBaseUrl(String url)` method.