### PR TITLE
Optimize tracingSpanToLineData and loggers

### DIFF
--- a/src/main/java/com/wavefront/sdk/common/logging/DelegatingLogger.java
+++ b/src/main/java/com/wavefront/sdk/common/logging/DelegatingLogger.java
@@ -30,6 +30,10 @@ public abstract class DelegatingLogger extends Logger {
   /** {@inheritDoc} */
   @Override
   public void log(LogRecord logRecord) {
+    if (!isLoggable(logRecord.getLevel())) {
+      // `inferCaller()` is a bit expensive, so return early.
+      return;
+    }
     logRecord.setLoggerName(delegate.getName());
     // Infer caller so that the log message contains the right '[source class] [source method]'
     // instead of 'DelegatingLogger log'

--- a/src/main/java/com/wavefront/sdk/common/logging/DelegatingLogger.java
+++ b/src/main/java/com/wavefront/sdk/common/logging/DelegatingLogger.java
@@ -31,7 +31,6 @@ public abstract class DelegatingLogger extends Logger {
   @Override
   public void log(LogRecord logRecord) {
     if (!isLoggable(logRecord.getLevel())) {
-      // `inferCaller()` is a bit expensive, so return early.
       return;
     }
     logRecord.setLoggerName(delegate.getName());

--- a/src/main/java/com/wavefront/sdk/common/logging/MessageDedupingLogger.java
+++ b/src/main/java/com/wavefront/sdk/common/logging/MessageDedupingLogger.java
@@ -45,6 +45,10 @@ public class MessageDedupingLogger extends DelegatingLogger {
   /** {@inheritDoc} */
   @Override
   public void log(Level level, String message) {
+    if (!isLoggable(level)) {
+      return;
+    }
+
     try {
       if (Objects.requireNonNull(rateLimiterCache.get(message)).tryAcquire()) {
         log(new LogRecord(level, message));
@@ -63,6 +67,10 @@ public class MessageDedupingLogger extends DelegatingLogger {
    * @param message             String to write to log.
    */
   public void log(String messageDedupingKey, Level level, String message) {
+    if (!isLoggable(level)) {
+      return;
+    }
+
     try {
       if (Objects.requireNonNull(rateLimiterCache.get(messageDedupingKey)).tryAcquire()) {
         log(new LogRecord(level, message));
@@ -82,6 +90,10 @@ public class MessageDedupingLogger extends DelegatingLogger {
    * @param thrown              Throwable associated with log message.
    */
   public void log(String messageDedupingKey, Level level, String message, Throwable thrown) {
+    if (!isLoggable(level)) {
+      return;
+    }
+
     LogRecord logRecord = new LogRecord(level, message);
     logRecord.setThrown(thrown);
     try {

--- a/src/main/java/com/wavefront/sdk/common/logging/MessageSuppressingLogger.java
+++ b/src/main/java/com/wavefront/sdk/common/logging/MessageSuppressingLogger.java
@@ -39,6 +39,10 @@ public class MessageSuppressingLogger extends DelegatingLogger {
    * @param message    Log message.
    */
   public void log(String messageKey, Level level, String message) {
+    if (!isLoggable(level)) {
+      return;
+    }
+
     cache.asMap().compute(messageKey,
         (key, prevTime) -> logMessageAndComputeTimestamp(message, level, prevTime));
   }
@@ -55,6 +59,10 @@ public class MessageSuppressingLogger extends DelegatingLogger {
   /** {@inheritDoc} */
   @Override
   public void log(Level level, String message) {
+    if (!isLoggable(level)) {
+      return;
+    }
+
     cache.asMap().compute(message,
         (key, prevTime) -> logMessageAndComputeTimestamp(message, level, prevTime));
   }

--- a/src/test/java/com/wavefront/sdk/common/logging/DelegatingLoggerTest.java
+++ b/src/test/java/com/wavefront/sdk/common/logging/DelegatingLoggerTest.java
@@ -1,0 +1,76 @@
+package com.wavefront.sdk.common.logging;
+
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link DelegatingLogger}.
+ *
+ * @author Glenn Oppegard (goppegard@vmware.com).
+ */
+class DelegatingLoggerTest {
+
+  @Test
+  void skipsDelegatingBasedOnLevel() {
+    Logger mockLogger = EasyMock.createMock(Logger.class);
+    reset(mockLogger);
+    expect(mockLogger.getName()).andReturn("loggerName").anyTimes();
+    replay(mockLogger);
+    DelegatingLoggerImpl log = new DelegatingLoggerImpl(mockLogger);
+
+    reset(mockLogger);
+    expect(mockLogger.getName()).andReturn("loggerName").anyTimes();
+    Capture<LogRecord> logs = Capture.newInstance(CaptureType.ALL);
+    mockLogger.log(capture(logs));
+    expectLastCall().times(5);
+    replay(mockLogger);
+
+    log.setLevel(Level.FINE);
+    log.severe("severe");
+    log.warning("warning");
+    log.info("info");
+    log.config("config");
+    log.fine("fine");
+
+    log.finer("not delegated");
+    log.finest("not delegated");
+
+    verify(mockLogger);
+    assertEquals(5, logs.getValues().size());
+    assertEquals("severe", logs.getValues().get(0).getMessage());
+    assertEquals(Level.SEVERE, logs.getValues().get(0).getLevel());
+    assertEquals("warning", logs.getValues().get(1).getMessage());
+    assertEquals(Level.WARNING, logs.getValues().get(1).getLevel());
+    assertEquals("info", logs.getValues().get(2).getMessage());
+    assertEquals(Level.INFO, logs.getValues().get(2).getLevel());
+    assertEquals("config", logs.getValues().get(3).getMessage());
+    assertEquals(Level.CONFIG, logs.getValues().get(3).getLevel());
+    assertEquals("fine", logs.getValues().get(4).getMessage());
+    assertEquals(Level.FINE, logs.getValues().get(4).getLevel());
+  }
+
+  class DelegatingLoggerImpl extends DelegatingLogger {
+    public DelegatingLoggerImpl(Logger delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public void log(Level level, String message) {
+      log(new LogRecord(level, message));
+    }
+  }
+}

--- a/src/test/java/com/wavefront/sdk/common/logging/MessageDedupingLoggerTest.java
+++ b/src/test/java/com/wavefront/sdk/common/logging/MessageDedupingLoggerTest.java
@@ -39,6 +39,7 @@ public class MessageDedupingLoggerTest {
     expectLastCall().times(5);
     replay(mockLogger);
 
+    log.setLevel(Level.ALL);
     log.severe("msg1");
     log.severe("msg1");
     log.warning("msg1");


### PR DESCRIPTION
- Estimate `StringBuilder` capacity in `tracingSpanToLineData()` to reduce memory allocations
- Return early from loggers based on `Level`

[K8SSASS-2541]